### PR TITLE
Add filtered replication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,8 +925,8 @@ version = "0.1.1"
 dependencies = [
  "md-5",
  "rouchdb-adapter-memory",
- "rouchdb-changes",
  "rouchdb-core",
+ "rouchdb-query",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/rouchdb-replication/Cargo.toml
+++ b/crates/rouchdb-replication/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 rouchdb-core = { path = "../rouchdb-core", version = "0.1.1" }
-rouchdb-changes = { path = "../rouchdb-changes", version = "0.1.1" }
+rouchdb-query = { path = "../rouchdb-query", version = "0.1.1" }
 md-5 = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rouchdb-replication/src/lib.rs
+++ b/crates/rouchdb-replication/src/lib.rs
@@ -12,4 +12,6 @@ mod checkpoint;
 mod protocol;
 
 pub use checkpoint::Checkpointer;
-pub use protocol::{ReplicationEvent, ReplicationOptions, ReplicationResult, replicate};
+pub use protocol::{
+    ReplicationEvent, ReplicationFilter, ReplicationOptions, ReplicationResult, replicate,
+};

--- a/crates/rouchdb/src/lib.rs
+++ b/crates/rouchdb/src/lib.rs
@@ -51,7 +51,9 @@ pub use rouchdb_query::{
     FindOptions, FindResponse, ReduceFn, SortField, ViewQueryOptions, ViewResult, find,
     matches_selector, query_view,
 };
-pub use rouchdb_replication::{ReplicationEvent, ReplicationOptions, ReplicationResult, replicate};
+pub use rouchdb_replication::{
+    ReplicationEvent, ReplicationFilter, ReplicationOptions, ReplicationResult, replicate,
+};
 
 /// A high-level database handle that wraps any adapter implementation.
 ///
@@ -464,6 +466,7 @@ mod tests {
                 ReplicationOptions {
                     batch_size: 1,
                     batches_limit: 10,
+                    ..Default::default()
                 },
             )
             .await

--- a/docs/book/src/architecture/replication-protocol.md
+++ b/docs/book/src/architecture/replication-protocol.md
@@ -239,14 +239,20 @@ The loop terminates when a changes response returns fewer results than
 
 ```rust
 pub struct ReplicationOptions {
-    pub batch_size: u64,       // default: 100
-    pub batches_limit: u64,    // default: 10
+    pub batch_size: u64,                   // default: 100
+    pub batches_limit: u64,                // default: 10
+    pub filter: Option<ReplicationFilter>, // default: None
 }
 ```
 
 - `batch_size` -- number of change events to process per iteration.
 - `batches_limit` -- maximum number of batches to buffer (reserved for
   future pipelining).
+- `filter` -- optional filter for selective replication. Supports
+  `DocIds(Vec<String>)`, `Selector(serde_json::Value)`, or
+  `Custom(Box<dyn Fn(&ChangeEvent) -> bool>)`. When `DocIds` is used,
+  filtering happens at the changes feed level. `Selector` filters after
+  `bulk_get`. `Custom` filters after fetching changes.
 
 ## Result
 

--- a/docs/book/src/reference/database-api.md
+++ b/docs/book/src/reference/database-api.md
@@ -119,6 +119,15 @@ All replication methods implement the CouchDB replication protocol: checkpoint r
 |-------|------|---------|-------------|
 | `batch_size` | `u64` | `100` | Number of documents to process per batch. |
 | `batches_limit` | `u64` | `10` | Maximum number of batches to buffer. |
+| `filter` | `Option<ReplicationFilter>` | `None` | Optional filter for selective replication. |
+
+### ReplicationFilter
+
+| Variant | Description |
+|---------|-------------|
+| `DocIds(Vec<String>)` | Replicate only the listed document IDs. Filtering at the changes feed level (most efficient). |
+| `Selector(serde_json::Value)` | Replicate documents matching a Mango selector. Evaluated after fetching documents. |
+| `Custom(Box<dyn Fn(&ChangeEvent) -> bool + Send + Sync>)` | Replicate documents passing a custom predicate applied to each change event. |
 
 ### ReplicationResult
 


### PR DESCRIPTION
## Summary

- Add `ReplicationFilter` enum with three variants for selective replication:
  - `DocIds(Vec<String>)` — replicate only listed document IDs (filtered at the changes feed level)
  - `Selector(serde_json::Value)` — replicate documents matching a Mango query (filtered after bulk_get)
  - `Custom(Box<dyn Fn(&ChangeEvent) -> bool>)` — replicate documents passing a Rust closure (filtered after changes)
- Add optional `filter` field to `ReplicationOptions`
- Remove unused `rouchdb-changes` dependency from `rouchdb-replication`
- Update docs (EN + ES): guides, architecture, API reference

## Test plan

- [x] 6 unit tests in `rouchdb-replication`: doc_ids, selector, custom closure, incremental, deletes, no-filter unchanged
- [x] 2 integration tests against CouchDB: doc_ids push, selector pull
- [x] All 156 existing tests still pass
- [x] Clippy clean, fmt clean, mdBook builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)