### PR TITLE
chore: bump to v0.3.2 — update repo URL for org rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project follows [Semantic Versioning](https://semver.org/). Since we are pr
 
 ---
 
+## [0.3.2] — 2026-02-13
+
+### Changes
+
+- Update repository URL from `github.com/RubyLabApp/rouchdb` to `github.com/rubylab-app/rouchdb` following organization rename
+
+---
+
 ## [0.3.0] — 2026-02-12
 
 ### New Crates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ This project follows [Semantic Versioning](https://semver.org/). Since we are pr
 
 ---
 
+## [0.3.1] — 2026-02-12
+
+### Fixes
+
+- Add fauxton `.gitkeep` so the `fauxton/` directory exists in CI (rust-embed requires it)
+- Fix `cargo fmt` formatting in CLI and server session routes
+
+---
+
 ## [0.3.0] — 2026-02-12
 
 ### New Crates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-adapter-http"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-adapter-memory"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-adapter-redb"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-changes"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "rouchdb-adapter-memory",
  "rouchdb-core",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-query"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "regex",
  "rouchdb-adapter-memory",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-replication"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "md-5",
  "rouchdb-adapter-memory",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-server"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "axum",
  "clap",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-views"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "rouchdb-adapter-memory",
  "rouchdb-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/RubyLabApp/rouchdb"
-homepage = "https://github.com/RubyLabApp/rouchdb"
+repository = "https://github.com/rubylab-app/rouchdb"
+homepage = "https://github.com/rubylab-app/rouchdb"
 keywords = ["database", "couchdb", "pouchdb", "replication", "local-first"]
 categories = ["database", "data-structures"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 RubyLabApp
+Copyright (c) 2026 rubylab-app
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ RouchDB is the Rust equivalent of [PouchDB](https://pouchdb.com/) — it stores 
 
 [![Crates.io](https://img.shields.io/crates/v/rouchdb)](https://crates.io/crates/rouchdb)
 [![Docs](https://img.shields.io/docsrs/rouchdb)](https://docs.rs/rouchdb)
-[![CI](https://github.com/RubyLabApp/rouchdb/actions/workflows/ci.yml/badge.svg)](https://github.com/RubyLabApp/rouchdb/actions/workflows/ci.yml)
+[![CI](https://github.com/rubylab-app/rouchdb/actions/workflows/ci.yml/badge.svg)](https://github.com/rubylab-app/rouchdb/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ## Features

--- a/crates/rouchdb-adapter-http/Cargo.toml
+++ b/crates/rouchdb-adapter-http/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.1" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
 async-trait = "0.1"
 percent-encoding = "2"
 reqwest = { version = "0.12", features = ["json", "cookies"] }

--- a/crates/rouchdb-adapter-memory/Cargo.toml
+++ b/crates/rouchdb-adapter-memory/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.1" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
 async-trait = "0.1"
 base64 = "0.22"
 md-5 = "0.10"

--- a/crates/rouchdb-adapter-redb/Cargo.toml
+++ b/crates/rouchdb-adapter-redb/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.1" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
 async-trait = "0.1"
 base64 = "0.22"
 md-5 = "0.10"

--- a/crates/rouchdb-changes/Cargo.toml
+++ b/crates/rouchdb-changes/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.1" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
 tokio = { version = "1", features = ["sync", "time", "macros", "rt"] }
 tokio-util = "0.7"
 serde_json = "1"

--- a/crates/rouchdb-query/Cargo.toml
+++ b/crates/rouchdb-query/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.1" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rouchdb-replication/Cargo.toml
+++ b/crates/rouchdb-replication/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.1" }
-rouchdb-query = { path = "../rouchdb-query", version = "0.3.1" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
+rouchdb-query = { path = "../rouchdb-query", version = "0.3.2" }
 md-5 = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rouchdb-server/Cargo.toml
+++ b/crates/rouchdb-server/Cargo.toml
@@ -12,8 +12,8 @@ name = "rouchdb-server"
 path = "src/main.rs"
 
 [dependencies]
-rouchdb = { path = "../rouchdb", version = "0.3.1" }
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.1" }
+rouchdb = { path = "../rouchdb", version = "0.3.2" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
 clap = { version = "4", features = ["derive"] }
 axum = "0.8"
 tower-http = { version = "0.6", features = ["cors"] }

--- a/crates/rouchdb-views/Cargo.toml
+++ b/crates/rouchdb-views/Cargo.toml
@@ -11,10 +11,10 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.1" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-rouchdb-adapter-memory = { path = "../rouchdb-adapter-memory", version = "0.3.1" }
+rouchdb-adapter-memory = { path = "../rouchdb-adapter-memory", version = "0.3.2" }

--- a/crates/rouchdb/Cargo.toml
+++ b/crates/rouchdb/Cargo.toml
@@ -12,14 +12,14 @@ readme.workspace = true
 
 [dependencies]
 async-trait = "0.1"
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.1" }
-rouchdb-adapter-memory = { path = "../rouchdb-adapter-memory", version = "0.3.1" }
-rouchdb-adapter-redb = { path = "../rouchdb-adapter-redb", version = "0.3.1" }
-rouchdb-adapter-http = { path = "../rouchdb-adapter-http", version = "0.3.1" }
-rouchdb-changes = { path = "../rouchdb-changes", version = "0.3.1" }
-rouchdb-replication = { path = "../rouchdb-replication", version = "0.3.1" }
-rouchdb-query = { path = "../rouchdb-query", version = "0.3.1" }
-rouchdb-views = { path = "../rouchdb-views", version = "0.3.1" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
+rouchdb-adapter-memory = { path = "../rouchdb-adapter-memory", version = "0.3.2" }
+rouchdb-adapter-redb = { path = "../rouchdb-adapter-redb", version = "0.3.2" }
+rouchdb-adapter-http = { path = "../rouchdb-adapter-http", version = "0.3.2" }
+rouchdb-changes = { path = "../rouchdb-changes", version = "0.3.2" }
+rouchdb-replication = { path = "../rouchdb-replication", version = "0.3.2" }
+rouchdb-query = { path = "../rouchdb-query", version = "0.3.2" }
+rouchdb-views = { path = "../rouchdb-views", version = "0.3.2" }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 tokio = { version = "1", features = ["sync"] }

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -11,4 +11,4 @@ build-dir = "book"
 [output.html]
 default-theme = "rust"
 preferred-dark-theme = "ayu"
-git-repository-url = "https://github.com/RubyLabApp/rouchdb"
+git-repository-url = "https://github.com/rubylab-app/rouchdb"

--- a/docs/book/src/contributing/setup.md
+++ b/docs/book/src/contributing/setup.md
@@ -33,7 +33,7 @@ Docker is **not** required for building the project or running unit tests.
 ## Clone and Build
 
 ```bash
-git clone https://github.com/RubyLabApp/rouchdb.git
+git clone https://github.com/rubylab-app/rouchdb.git
 cd rouchdb
 cargo build
 ```


### PR DESCRIPTION
## Summary

- Update all repository URLs from `github.com/RubyLabApp/rouchdb` to `github.com/rubylab-app/rouchdb` following the GitHub organization rename
- Bump workspace version from 0.3.1 to 0.3.2 across all 11 crates
- Update git remote, LICENSE copyright, CI badge links, docs, and clone instructions

## Files changed

- `Cargo.toml` (workspace) — version + repository/homepage URLs
- `crates/*/Cargo.toml` (10 crates) — internal dependency versions
- `README.md` — CI badge URLs
- `CHANGELOG.md` — new 0.3.2 entry
- `LICENSE` — copyright holder name
- `docs/book/book.toml` — git-repository-url
- `docs/book/src/contributing/setup.md` — clone URL

## Test plan

- [x] `cargo check --workspace` passes
- [ ] CI passes (fmt, clippy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)