### PR TITLE
Fix 44 bugs from deep audit (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,117 @@ This project follows [Semantic Versioning](https://semver.org/). Since we are pr
 
 ---
 
+## [0.4.0] — 2026-06-09
+
+Correctness release. A deep audit fixed **44 bugs** across every crate. There are no new features, but several fixes change observable behavior (HTTP status codes, replication checkpoints) or public type shapes — **read the migration guide before upgrading.**
+
+### Migration Guide (0.3.2 → 0.4.0)
+
+#### Breaking Changes — API
+
+1. **`ChangesEvent` has a new `Heartbeat` variant.** An exhaustive `match` without a wildcard arm will no longer compile. Add an arm:
+   ```rust
+   ChangesEvent::Heartbeat => { /* keep-alive tick; ignore or reset a timeout */ }
+   ```
+   Heartbeats are emitted by `live_changes_events` only when `ChangesStreamOptions.heartbeat` is set (the option was previously inert).
+
+2. **`DbInfo` has a new field `doc_del_count: u64`.** If you build it with struct-literal syntax, add the field or use `..Default::default()`. It now reports the real deleted-document count (was hardcoded to `0` in the server response).
+
+3. **`SecurityDocument` has a new field `extra: serde_json::Map<String, Value>`** — a `#[serde(flatten)]` catch-all so CouchDB's arbitrary `_security` fields round-trip instead of being dropped. Add `..Default::default()` to struct literals.
+
+4. **`CheckpointDoc` gained a `_rev` field and `Checkpointer::new` takes a third argument** (a filter fingerprint): `Checkpointer::new(source_id, target_id, filter_fingerprint)`. Only affects code that constructs these `rouchdb-replication` types directly.
+
+#### Breaking Changes — Behavior
+
+5. **Replication checkpoints are invalidated once.** The replication ID now incorporates the filter (and uses a revised hashing scheme), so the first replication after upgrading re-reads from sequence 0. This is a one-time, **idempotent** re-scan (no data loss or duplicates, thanks to `revs_diff`); subsequent runs resume normally from the new checkpoint.
+
+6. **HTTP server status codes now match CouchDB:**
+   - `PUT /{db}/{docid}` returns **409 Conflict** on a stale/missing `_rev` (was 201 Created).
+   - `DELETE /{db}/{docid}` returns **409 / 404** on conflict / not-found (was 200 OK).
+   - `PUT /{db}` returns **412 file_exists** when the database already exists (was 201).
+
+   Clients that treated the old (incorrect) codes as success must update their handling.
+
+7. **`PUT /{db}/{docid}` with `{"_deleted": true}` now deletes the document** (previously it silently created a new live revision).
+
+8. **`get(rev = X, latest = true)`** now returns the leaf of *X's own branch*, not the global winning leaf. Only affects conflicted documents.
+
+9. **An empty map/reduce now returns `{"rows": []}`** instead of one `{"key": null, "value": 0}` row (matches CouchDB). Code that indexes `rows[0]` unconditionally must guard for emptiness.
+
+10. **`Revision` parsing rejects an empty hash** (e.g. `"3-"`) with `InvalidRev`; such strings previously parsed successfully.
+
+11. **`put` / `update` / `remove` return `Err(DatabaseError)`** instead of panicking when a `before_write` plugin removes the document from the batch.
+
+### Bug Fixes
+
+**Core (revision tree, collation, model):**
+- Stemming stopped at the first conflict branch point, so `revs_limit` was never enforced on conflicted documents (unbounded rev-tree growth). It now prunes past branch points by re-rooting subtrees.
+- Collation lost precision on integers above 2⁵³, collapsing distinct values to `Equal` and breaking Mango `$eq`/range queries. Integers are now compared exactly.
+- Inline attachment data serialized as a JSON byte array instead of a base64 string (malformed CouchDB output).
+- `Revision::from_str` accepted a missing hash (`"{pos}-"`).
+
+**Memory adapter:**
+- `put_attachment` reported success but discarded the attachment — bytes were unrecoverable. Attachments are now persisted per revision and round-trip through `get_attachment` and replication.
+- `get(latest = true)` returned the global winner instead of the requested branch's leaf.
+- `style=all_docs` emitted an empty `changes` array for fully-deleted documents.
+- `changes` reported `last_seq = since` when every change was filtered out (endless re-scans).
+- `all_docs` `total_rows` reflected the filtered count instead of the database total.
+
+**Redb adapter:**
+- `all_docs` descending key-range used ascending comparisons, returning the wrong rows.
+- `all_docs` ignored `conflicts`, omitting `_conflicts` from included docs.
+- `changes` panicked on a single corrupt/undeserializable record (now propagates an error).
+- `info()` / `all_docs` read `update_seq` in a separate transaction from the document snapshot (TOCTOU); now a single read transaction.
+
+**HTTP adapter:**
+- `all_docs` ignored `key`, `keys`, and `inclusive_end`.
+- `startkey` / `endkey` / `key` / `open_revs` were spliced into the URL unencoded (broke on special characters and unicode).
+- Design-document ids were encoded as `_design%2Fx`, breaking routing; the prefix slash is now preserved.
+
+**Query (Mango + map/reduce):**
+- `$elemMatch` with an operator expression failed on arrays of scalars.
+- `skip` / `limit` were ignored on reduced/grouped output.
+- `group_level=0` did not collapse into a single global group.
+- Reduce over an empty result set returned a spurious zero row.
+
+**Views:**
+- Design documents containing a `views.lib` (CommonJS shared library) entry failed to parse.
+
+**Replication:**
+- Replication ID omitted the filter, so different filters shared a checkpoint (silent data loss).
+- Checkpoint `_local` doc was written without `_rev`, so every CouchDB checkpoint update after the first failed with 409.
+- Checkpoint history was reset to a single entry on every write, breaking cross-session resume.
+- `compare_checkpoints` compared opaque CouchDB sequences by numeric prefix; transient checkpoint read errors were swallowed as "no checkpoint."
+- The checkpoint advanced past documents that failed to parse or write (permanent data loss with no resume); `docs_written` counted failed writes.
+- Attachments were dropped during replication (now carried end-to-end between memory adapters).
+- Live replication emitted a `Complete` event on every poll iteration instead of once at the end.
+
+**Changes feed:**
+- `limit` counted pre-filter changes, so a filtered live feed delivered fewer than `limit` matches.
+- The `heartbeat` option was declared but never honored.
+
+**Umbrella (`Database`):**
+- Index-accelerated `find()` ignored dotted/nested sort fields (e.g. `address.city`).
+- `put` / `update` / `remove` panicked when a plugin dropped the document.
+
+**HTTP server:**
+- Wrong status codes on conflict/not-found and on existing-database `PUT` (see migration notes).
+- `since=now` mapped to `u64::MAX`, causing an integer overflow.
+- `PUT` ignored `_deleted` in the body.
+- Attachment downloads guessed the content type from the filename, discarding the stored `content_type`.
+- `doc_del_count` was hardcoded to `0`.
+- `PUT /{db}/_security` dropped any fields outside `admins`/`members`.
+
+**CLI:**
+- `import` exited `0` even when documents failed.
+- `put --force` swallowed non-`NotFound` errors from `get` and silently created instead of updating.
+
+### Tests
+
+- 366 unit tests passing (≈25 new regression tests); `clippy -D warnings` and `cargo fmt --check` clean.
+
+---
+
 ## [0.3.2] — 2026-02-13
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-adapter-http"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-adapter-memory"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-adapter-redb"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-changes"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "rouchdb-adapter-memory",
  "rouchdb-core",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-cli"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-core"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-query"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "regex",
  "rouchdb-adapter-memory",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-replication"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "md-5",
  "rouchdb-adapter-memory",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-server"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "axum",
  "clap",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "rouchdb-views"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "rouchdb-adapter-memory",
  "rouchdb-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 readme = "README.md"

--- a/crates/rouchdb-adapter-http/Cargo.toml
+++ b/crates/rouchdb-adapter-http/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.4.0" }
 async-trait = "0.1"
 percent-encoding = "2"
 reqwest = { version = "0.12", features = ["json", "cookies"] }

--- a/crates/rouchdb-adapter-http/src/lib.rs
+++ b/crates/rouchdb-adapter-http/src/lib.rs
@@ -23,6 +23,8 @@ use rouchdb_core::error::{Result, RouchError};
 struct CouchDbInfo {
     db_name: String,
     doc_count: u64,
+    #[serde(default)]
+    doc_del_count: u64,
     update_seq: serde_json::Value, // Can be integer or string depending on CouchDB version
 }
 
@@ -244,12 +246,13 @@ impl Adapter for HttpAdapter {
         Ok(DbInfo {
             db_name: info.db_name,
             doc_count: info.doc_count,
+            doc_del_count: info.doc_del_count,
             update_seq: parse_seq(&info.update_seq),
         })
     }
 
     async fn get(&self, id: &str, opts: GetOptions) -> Result<Document> {
-        let mut url = self.url(&urlencoded(id));
+        let mut url = self.url(&encode_doc_id(id));
         let mut params = Vec::new();
 
         if let Some(ref rev) = opts.rev {
@@ -275,7 +278,7 @@ impl Adapter for HttpAdapter {
                 OpenRevs::All => params.push("open_revs=all".into()),
                 OpenRevs::Specific(revs) => {
                     let json = serde_json::to_string(revs).unwrap_or_default();
-                    params.push(format!("open_revs={}", json));
+                    params.push(format!("open_revs={}", urlencoded(&json)));
                 }
             }
         }
@@ -346,10 +349,16 @@ impl Adapter for HttpAdapter {
             params.push("descending=true".into());
         }
         if let Some(ref start) = opts.start_key {
-            params.push(format!("startkey=\"{}\"", start));
+            params.push(format!("startkey={}", encode_query_key(start)));
         }
         if let Some(ref end) = opts.end_key {
-            params.push(format!("endkey=\"{}\"", end));
+            params.push(format!("endkey={}", encode_query_key(end)));
+        }
+        if let Some(ref k) = opts.key {
+            params.push(format!("key={}", encode_query_key(k)));
+        }
+        if !opts.inclusive_end {
+            params.push("inclusive_end=false".into());
         }
         if let Some(limit) = opts.limit {
             params.push(format!("limit={}", limit));
@@ -369,12 +378,18 @@ impl Adapter for HttpAdapter {
             url = format!("{}?{}", url, params.join("&"));
         }
 
-        let resp = self
-            .client
-            .get(&url)
-            .send()
-            .await
-            .map_err(|e| RouchError::DatabaseError(e.to_string()))?;
+        // Multiple keys are sent via a POST body (CouchDB `_all_docs` keys
+        // form); everything else is a GET.
+        let resp = if let Some(ref keys) = opts.keys {
+            self.client
+                .post(&url)
+                .json(&serde_json::json!({ "keys": keys }))
+                .send()
+                .await
+        } else {
+            self.client.get(&url).send().await
+        }
+        .map_err(|e| RouchError::DatabaseError(e.to_string()))?;
         let resp = self.check_error(resp).await?;
         let result: CouchDbAllDocsResponse = resp
             .json()
@@ -556,7 +571,7 @@ impl Adapter for HttpAdapter {
     ) -> Result<DocResult> {
         let url = format!(
             "{}/{}?rev={}",
-            self.url(&urlencoded(doc_id)),
+            self.url(&encode_doc_id(doc_id)),
             urlencoded(att_id),
             rev
         );
@@ -590,7 +605,11 @@ impl Adapter for HttpAdapter {
         att_id: &str,
         opts: GetAttachmentOptions,
     ) -> Result<Vec<u8>> {
-        let mut url = format!("{}/{}", self.url(&urlencoded(doc_id)), urlencoded(att_id));
+        let mut url = format!(
+            "{}/{}",
+            self.url(&encode_doc_id(doc_id)),
+            urlencoded(att_id)
+        );
         if let Some(ref rev) = opts.rev {
             url = format!("{}?rev={}", url, rev);
         }
@@ -613,7 +632,7 @@ impl Adapter for HttpAdapter {
     async fn remove_attachment(&self, doc_id: &str, att_id: &str, rev: &str) -> Result<DocResult> {
         let url = format!(
             "{}/{}?rev={}",
-            self.url(&urlencoded(doc_id)),
+            self.url(&encode_doc_id(doc_id)),
             urlencoded(att_id),
             rev
         );
@@ -767,4 +786,59 @@ fn urlencoded(s: &str) -> String {
         .remove(b'.')
         .remove(b'~');
     percent_encoding::percent_encode(s.as_bytes(), UNRESERVED).to_string()
+}
+
+/// Encode a document id for use in a CouchDB URL path.
+///
+/// Like PouchDB's `encodeDocId`, the `/` separating the `_design/` or
+/// `_local/` prefix from the rest of the id is kept literal so CouchDB routes
+/// design-doc (and `_local`) sub-resources correctly. Without this, an id like
+/// `_design/foo` would be encoded to `_design%2Ffoo` and mis-routed.
+fn encode_doc_id(id: &str) -> String {
+    if let Some(rest) = id.strip_prefix("_design/") {
+        format!("_design/{}", urlencoded(rest))
+    } else if let Some(rest) = id.strip_prefix("_local/") {
+        format!("_local/{}", urlencoded(rest))
+    } else {
+        urlencoded(id)
+    }
+}
+
+/// JSON-encode a key value and percent-encode it for safe use as a query
+/// parameter (handles `"`, `\`, control chars, `&`, `#`, spaces, unicode).
+fn encode_query_key(value: &str) -> String {
+    let json = serde_json::to_string(value).unwrap_or_else(|_| "\"\"".into());
+    urlencoded(&json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{encode_doc_id, encode_query_key, urlencoded};
+
+    #[test]
+    fn design_and_local_ids_keep_prefix_slash() {
+        // The slash after the _design/ or _local/ prefix must stay literal.
+        assert_eq!(encode_doc_id("_design/foo"), "_design/foo");
+        assert_eq!(encode_doc_id("_local/checkpoint"), "_local/checkpoint");
+        // But a slash inside the rest of the id is still encoded.
+        assert_eq!(encode_doc_id("_design/a/b"), "_design/a%2Fb");
+        // Plain ids: slashes and specials encoded as before.
+        assert_eq!(encode_doc_id("a/b"), "a%2Fb");
+        assert_eq!(encode_doc_id("user:alice"), urlencoded("user:alice"));
+    }
+
+    #[test]
+    fn query_keys_are_json_and_url_encoded() {
+        // A plain string becomes a JSON-quoted, percent-encoded value.
+        assert_eq!(encode_query_key("abc"), "%22abc%22");
+        // Special characters that would break a query string are escaped.
+        let encoded = encode_query_key("a&b=c #d");
+        assert!(!encoded.contains('&'));
+        assert!(!encoded.contains('#'));
+        assert!(!encoded.contains(' '));
+        // Unicode is percent-encoded, not spliced raw.
+        let uni = encode_query_key("\u{ffff}");
+        assert!(uni.starts_with("%22") && uni.ends_with("%22"));
+        assert!(uni.contains('%'));
+    }
 }

--- a/crates/rouchdb-adapter-memory/Cargo.toml
+++ b/crates/rouchdb-adapter-memory/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.4.0" }
 async-trait = "0.1"
 base64 = "0.22"
 md-5 = "0.10"

--- a/crates/rouchdb-adapter-memory/src/lib.rs
+++ b/crates/rouchdb-adapter-memory/src/lib.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use rouchdb_core::adapter::Adapter;
 use rouchdb_core::document::*;
 use rouchdb_core::error::{Result, RouchError};
-use rouchdb_core::merge::{collect_conflicts, is_deleted, merge_tree, winning_rev};
+use rouchdb_core::merge::{collect_conflicts, is_deleted, latest_leaf, merge_tree, winning_rev};
 use rouchdb_core::rev_tree::{
     NodeOpts, RevPath, RevStatus, RevTree, build_path_from_revs, collect_leaves, find_rev_ancestry,
     rev_exists,
@@ -28,6 +28,8 @@ struct StoredDoc {
     rev_data: HashMap<String, serde_json::Value>,
     /// Map from "pos-hash" to the deleted flag at that revision.
     rev_deleted: HashMap<String, bool>,
+    /// Map from "pos-hash" to that revision's attachments (att_id -> meta).
+    rev_attachments: HashMap<String, HashMap<String, AttachmentMeta>>,
     /// Current sequence number for this document.
     seq: u64,
 }
@@ -120,18 +122,20 @@ fn compute_attachment_digest(data: &[u8]) -> String {
 impl Adapter for MemoryAdapter {
     async fn info(&self) -> Result<DbInfo> {
         let inner = self.inner.read().await;
-        let doc_count = inner
-            .docs
-            .values()
-            .filter(|d| {
-                // Count only non-deleted documents
-                !is_deleted(&d.rev_tree)
-            })
-            .count() as u64;
+        let mut doc_count = 0u64;
+        let mut doc_del_count = 0u64;
+        for d in inner.docs.values() {
+            if is_deleted(&d.rev_tree) {
+                doc_del_count += 1;
+            } else {
+                doc_count += 1;
+            }
+        }
 
         Ok(DbInfo {
             db_name: inner.name.clone(),
             doc_count,
+            doc_del_count,
             update_seq: Seq::Num(inner.update_seq),
         })
     }
@@ -153,13 +157,14 @@ impl Adapter for MemoryAdapter {
             winner.to_string()
         };
 
-        // latest: if requested rev isn't a leaf, return the latest leaf instead
-        if opts.latest && opts.rev.is_some() {
-            let leaves = collect_leaves(&stored.rev_tree);
-            let is_leaf = leaves.iter().any(|l| l.rev_string() == target_rev);
-            if !is_leaf && let Some(leaf) = leaves.first() {
-                target_rev = leaf.rev_string();
-            }
+        // latest: walk the requested rev's own branch down to its winning leaf
+        // (returns the rev unchanged when it is already a leaf).
+        if opts.latest
+            && opts.rev.is_some()
+            && let Ok((pos, hash)) = parse_rev(&target_rev)
+            && let Some(rev) = latest_leaf(&stored.rev_tree, pos, &hash)
+        {
+            target_rev = rev.to_string();
         }
 
         // Get the data for this revision
@@ -190,6 +195,22 @@ impl Adapter for MemoryAdapter {
             data,
             attachments: HashMap::new(),
         };
+
+        // Populate attachment metadata for this revision (inlining bytes only
+        // when explicitly requested via opts.attachments).
+        if let Some(atts) = stored.rev_attachments.get(&target_rev) {
+            for (name, meta) in atts {
+                let mut meta = meta.clone();
+                if opts.attachments {
+                    meta.data = inner.attachments.get(&meta.digest).cloned();
+                    meta.stub = meta.data.is_none();
+                } else {
+                    meta.data = None;
+                    meta.stub = true;
+                }
+                doc.attachments.insert(name.clone(), meta);
+            }
+        }
 
         // Add conflicts if requested
         if opts.conflicts {
@@ -367,8 +388,18 @@ impl Adapter for MemoryAdapter {
             }
         }
 
+        // total_rows is the total number of non-deleted documents in the
+        // database, independent of key range / key / keys / skip / limit
+        // (CouchDB semantics).
+        let total_rows = inner
+            .docs
+            .values()
+            .filter(|stored| {
+                winning_rev(&stored.rev_tree).is_some() && !is_deleted(&stored.rev_tree)
+            })
+            .count() as u64;
+
         // Apply skip and limit
-        let total_rows = rows.len() as u64;
         let skip = opts.skip as usize;
         if skip > 0 {
             rows = rows.into_iter().skip(skip).collect();
@@ -395,9 +426,14 @@ impl Adapter for MemoryAdapter {
         let inner = self.inner.read().await;
 
         let mut results = Vec::new();
+        // Highest sequence actually inspected (even if filtered out), so the
+        // feed's last_seq advances past a fully-filtered range instead of
+        // sticking at `since` and forcing endless re-scans.
+        let mut max_scanned: Option<u64> = None;
 
-        // Iterate changes after `since`
-        let range = (opts.since.as_num() + 1)..;
+        // Iterate changes after `since` (saturating so a huge `since` such as
+        // an unresolved "now" can never overflow).
+        let range = (opts.since.as_num().saturating_add(1))..;
         let iter: Box<dyn Iterator<Item = (&u64, &(String, bool))>> = if opts.descending {
             Box::new(
                 inner
@@ -412,6 +448,8 @@ impl Adapter for MemoryAdapter {
         };
 
         for (seq, (doc_id, deleted)) in iter {
+            max_scanned = Some(max_scanned.map_or(*seq, |m| m.max(*seq)));
+
             // Filter by doc_ids if specified
             if let Some(ref doc_ids) = opts.doc_ids
                 && !doc_ids.contains(doc_id)
@@ -447,9 +485,11 @@ impl Adapter for MemoryAdapter {
             // Build changes list based on style
             let changes_list = if opts.style == ChangesStyle::AllDocs {
                 if let Some(s) = stored {
+                    // All leaf revisions, including deleted ones, so a fully
+                    // deleted document still reports a non-empty `changes`
+                    // array (deletion is signaled by the `deleted` field).
                     collect_leaves(&s.rev_tree)
                         .iter()
-                        .filter(|l| !s.rev_deleted.get(&l.rev_string()).copied().unwrap_or(false))
                         .map(|l| ChangeRev {
                             rev: l.rev_string(),
                         })
@@ -496,6 +536,7 @@ impl Adapter for MemoryAdapter {
         let last_seq = results
             .last()
             .map(|r| r.seq.clone())
+            .or_else(|| max_scanned.map(Seq::Num))
             .unwrap_or(opts.since.clone());
 
         Ok(ChangesResponse { results, last_seq })
@@ -603,6 +644,40 @@ impl Adapter for MemoryAdapter {
                                     "ids": ancestry
                                 }),
                             );
+                        }
+
+                        // Include inline attachments so replication carries
+                        // their bytes end-to-end.
+                        if let Some(atts) = stored.rev_attachments.get(&rev_str)
+                            && !atts.is_empty()
+                        {
+                            use base64::Engine;
+                            let mut att_map = serde_json::Map::new();
+                            for (name, meta) in atts {
+                                let mut m = serde_json::Map::new();
+                                m.insert(
+                                    "content_type".into(),
+                                    serde_json::Value::String(meta.content_type.clone()),
+                                );
+                                m.insert(
+                                    "digest".into(),
+                                    serde_json::Value::String(meta.digest.clone()),
+                                );
+                                m.insert("length".into(), serde_json::json!(meta.length));
+                                if let Some(bytes) = inner.attachments.get(&meta.digest) {
+                                    m.insert(
+                                        "data".into(),
+                                        serde_json::Value::String(
+                                            base64::engine::general_purpose::STANDARD.encode(bytes),
+                                        ),
+                                    );
+                                    m.insert("stub".into(), serde_json::Value::Bool(false));
+                                } else {
+                                    m.insert("stub".into(), serde_json::Value::Bool(true));
+                                }
+                                att_map.insert(name.clone(), serde_json::Value::Object(m));
+                            }
+                            obj.insert("_attachments".into(), serde_json::Value::Object(att_map));
                         }
 
                         bulk_docs.push(BulkGetDoc {
@@ -726,21 +801,22 @@ impl Adapter for MemoryAdapter {
                 .to_string()
         };
 
-        // Look for attachment metadata in the doc data
-        // For now, look up by digest in our attachment store
-        // We'd need to track which attachments belong to which doc/rev
-        // For simplicity, search through our attachment map
-        let _data = stored.rev_data.get(&rev_str);
+        // Resolve the attachment metadata stored for this revision, then
+        // return the raw bytes held by digest.
+        let meta = stored
+            .rev_attachments
+            .get(&rev_str)
+            .and_then(|m| m.get(att_id))
+            .ok_or_else(|| RouchError::NotFound(format!("attachment {}/{}", doc_id, att_id)))?;
 
-        // TODO: proper attachment tracking per revision
-        Err(RouchError::NotFound(format!(
-            "attachment {}/{}",
-            doc_id, att_id
-        )))
+        inner
+            .attachments
+            .get(&meta.digest)
+            .cloned()
+            .ok_or_else(|| RouchError::NotFound(format!("attachment {}/{}", doc_id, att_id)))
     }
 
     async fn remove_attachment(&self, doc_id: &str, att_id: &str, rev: &str) -> Result<DocResult> {
-        let _ = att_id; // attachment tracking is simplified in memory adapter
         let mut inner = self.inner.write().await;
 
         let stored = inner
@@ -770,6 +846,15 @@ impl Adapter for MemoryAdapter {
         };
 
         let result = process_doc_new_edits(&mut inner, doc);
+
+        // The new revision carried the parent's attachments forward; drop the
+        // one being removed so it is no longer referenced.
+        if let Some(ref new_rev) = result.rev
+            && let Some(stored) = inner.docs.get_mut(doc_id)
+            && let Some(atts) = stored.rev_attachments.get_mut(new_rev)
+        {
+            atts.remove(att_id);
+        }
         Ok(result)
     }
 
@@ -808,6 +893,7 @@ impl Adapter for MemoryAdapter {
             // Remove data for non-leaf revisions
             stored.rev_data.retain(|k, _| leaf_revs.contains(k));
             stored.rev_deleted.retain(|k, _| leaf_revs.contains(k));
+            stored.rev_attachments.retain(|k, _| leaf_revs.contains(k));
         }
 
         Ok(())
@@ -834,6 +920,7 @@ impl Adapter for MemoryAdapter {
                 for rev_str in &revs {
                     if stored.rev_data.remove(rev_str).is_some() {
                         stored.rev_deleted.remove(rev_str);
+                        stored.rev_attachments.remove(rev_str);
                         purged_revs.push(rev_str.clone());
 
                         // Also prune the revision from the rev_tree so that
@@ -965,7 +1052,29 @@ fn process_doc_new_edits(inner: &mut Inner, doc: Document) -> DocResult {
     // Merge into existing tree or create new one
     let existing_tree = existing.map(|s| s.rev_tree.clone()).unwrap_or_default();
 
+    // Carry forward the parent revision's attachments so a body-only edit
+    // does not silently drop them.
+    let parent_atts: HashMap<String, AttachmentMeta> = doc
+        .rev
+        .as_ref()
+        .and_then(|r| existing.and_then(|s| s.rev_attachments.get(&r.to_string()).cloned()))
+        .unwrap_or_default();
+
     let (merged_tree, _merge_result) = merge_tree(&existing_tree, &new_path, DEFAULT_REV_LIMIT);
+
+    // Compute the new revision's attachment set: parent attachments plus any
+    // supplied with this edit (inline bytes are stored by digest).
+    let mut new_atts = parent_atts;
+    for (att_id, mut meta) in doc.attachments {
+        if let Some(bytes) = meta.data.take() {
+            let digest = compute_attachment_digest(&bytes);
+            meta.length = bytes.len() as u64;
+            meta.digest = digest.clone();
+            meta.stub = true;
+            inner.attachments.insert(digest, bytes);
+        }
+        new_atts.insert(att_id, meta);
+    }
 
     // Update sequence
     inner.update_seq += 1;
@@ -984,12 +1093,14 @@ fn process_doc_new_edits(inner: &mut Inner, doc: Document) -> DocResult {
             rev_tree: Vec::new(),
             rev_data: HashMap::new(),
             rev_deleted: HashMap::new(),
+            rev_attachments: HashMap::new(),
             seq: 0,
         });
 
     stored.rev_tree = merged_tree;
     stored.rev_data.insert(new_rev_str.clone(), doc.data);
     stored.rev_deleted.insert(new_rev_str.clone(), doc.deleted);
+    stored.rev_attachments.insert(new_rev_str.clone(), new_atts);
     stored.seq = seq;
 
     // Record in changes
@@ -1065,6 +1176,20 @@ fn process_doc_replication(inner: &mut Inner, mut doc: Document) -> DocResult {
         map.remove("_revisions");
     }
 
+    // Persist attachments carried by replication: inline bytes go to the
+    // attachment store, metadata to this revision's attachment map.
+    let mut new_atts: HashMap<String, AttachmentMeta> = HashMap::new();
+    for (att_id, mut meta) in std::mem::take(&mut doc.attachments) {
+        if let Some(bytes) = meta.data.take() {
+            let digest = compute_attachment_digest(&bytes);
+            meta.length = bytes.len() as u64;
+            meta.digest = digest.clone();
+            meta.stub = true;
+            inner.attachments.insert(digest, bytes);
+        }
+        new_atts.insert(att_id, meta);
+    }
+
     // Merge into existing tree
     let existing_tree = inner
         .docs
@@ -1092,12 +1217,14 @@ fn process_doc_replication(inner: &mut Inner, mut doc: Document) -> DocResult {
             rev_tree: Vec::new(),
             rev_data: HashMap::new(),
             rev_deleted: HashMap::new(),
+            rev_attachments: HashMap::new(),
             seq: 0,
         });
 
     stored.rev_tree = merged_tree;
     stored.rev_data.insert(rev_str.clone(), doc.data);
     stored.rev_deleted.insert(rev_str.clone(), doc.deleted);
+    stored.rev_attachments.insert(rev_str.clone(), new_atts);
     stored.seq = seq;
 
     inner.changes.insert(seq, (doc_id.clone(), is_doc_deleted));
@@ -1499,6 +1626,211 @@ mod tests {
         let info = db.info().await.unwrap();
         assert_eq!(info.doc_count, 0);
         assert_eq!(info.update_seq, Seq::Num(0));
+    }
+
+    #[tokio::test]
+    async fn attachment_roundtrip() {
+        let db = new_db().await;
+
+        let doc = Document {
+            id: "doc1".into(),
+            rev: None,
+            deleted: false,
+            data: serde_json::json!({"v": 1}),
+            attachments: HashMap::new(),
+        };
+        let r = db
+            .bulk_docs(vec![doc], BulkDocsOptions::new())
+            .await
+            .unwrap();
+        let rev1 = r[0].rev.clone().unwrap();
+
+        // Store an attachment; the bytes must be retrievable afterwards.
+        let r2 = db
+            .put_attachment("doc1", "hi.txt", &rev1, b"hi!".to_vec(), "text/plain")
+            .await
+            .unwrap();
+        assert!(r2.ok);
+        let rev2 = r2.rev.clone().unwrap();
+
+        let bytes = db
+            .get_attachment("doc1", "hi.txt", GetAttachmentOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(bytes, b"hi!");
+
+        // get with attachments=true exposes the metadata + inline data.
+        let fetched = db
+            .get(
+                "doc1",
+                GetOptions {
+                    attachments: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(fetched.attachments["hi.txt"].content_type, "text/plain");
+        assert_eq!(
+            fetched.attachments["hi.txt"].data.as_deref(),
+            Some(&b"hi!"[..])
+        );
+
+        // Removing the attachment makes it unretrievable on the new rev.
+        let r3 = db.remove_attachment("doc1", "hi.txt", &rev2).await.unwrap();
+        assert!(r3.ok);
+        let err = db
+            .get_attachment("doc1", "hi.txt", GetAttachmentOptions::default())
+            .await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn all_docs_total_rows_is_full_count() {
+        let db = new_db().await;
+        for name in ["a", "b", "c", "d"] {
+            let doc = Document {
+                id: name.into(),
+                rev: None,
+                deleted: false,
+                data: serde_json::json!({}),
+                attachments: HashMap::new(),
+            };
+            db.bulk_docs(vec![doc], BulkDocsOptions::new())
+                .await
+                .unwrap();
+        }
+
+        // Narrow the range to a single row; total_rows must still be 4.
+        let opts = AllDocsOptions {
+            start_key: Some("b".into()),
+            end_key: Some("b".into()),
+            ..AllDocsOptions::new()
+        };
+        let result = db.all_docs(opts).await.unwrap();
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.total_rows, 4);
+    }
+
+    #[tokio::test]
+    async fn changes_last_seq_advances_when_all_filtered() {
+        let db = new_db().await;
+        for i in 0..3 {
+            let doc = Document {
+                id: format!("doc{}", i),
+                rev: None,
+                deleted: false,
+                data: serde_json::json!({"i": i}),
+                attachments: HashMap::new(),
+            };
+            db.bulk_docs(vec![doc], BulkDocsOptions::new())
+                .await
+                .unwrap();
+        }
+
+        // doc_ids filter matches nothing, but last_seq must still reach the
+        // database's update_seq so polling doesn't re-scan forever.
+        let changes = db
+            .changes(ChangesOptions {
+                doc_ids: Some(vec!["nonexistent".into()]),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert!(changes.results.is_empty());
+        assert_eq!(changes.last_seq, Seq::Num(3));
+    }
+
+    #[tokio::test]
+    async fn changes_all_docs_style_nonempty_for_deleted() {
+        let db = new_db().await;
+        let r = db
+            .bulk_docs(
+                vec![Document {
+                    id: "doc1".into(),
+                    rev: None,
+                    deleted: false,
+                    data: serde_json::json!({"v": 1}),
+                    attachments: HashMap::new(),
+                }],
+                BulkDocsOptions::new(),
+            )
+            .await
+            .unwrap();
+        let rev1: Revision = r[0].rev.clone().unwrap().parse().unwrap();
+        db.bulk_docs(
+            vec![Document {
+                id: "doc1".into(),
+                rev: Some(rev1),
+                deleted: true,
+                data: serde_json::json!({}),
+                attachments: HashMap::new(),
+            }],
+            BulkDocsOptions::new(),
+        )
+        .await
+        .unwrap();
+
+        let changes = db
+            .changes(ChangesOptions {
+                style: ChangesStyle::AllDocs,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let ev = changes.results.iter().find(|e| e.id == "doc1").unwrap();
+        assert!(ev.deleted);
+        assert!(
+            !ev.changes.is_empty(),
+            "deleted doc must still list its leaf rev"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_latest_stays_on_requested_branch() {
+        let db = new_db().await;
+        // Two branches sharing ancestor 1-aaa, built via replication so the
+        // intermediate nodes are missing:
+        //   losing branch:  1-aaa -> 2-bbb -> 3-ccc  (leaf)
+        //   winning branch: 1-aaa -> 2-zzz -> 3-ddd -> 4-eee (leaf, the winner)
+        let branches = [
+            (3u64, "ccc", vec!["ccc", "bbb", "aaa"]),
+            (4u64, "eee", vec!["eee", "ddd", "zzz", "aaa"]),
+        ];
+        for (pos, hash, ids) in branches {
+            let mut data = serde_json::json!({ "v": hash });
+            data.as_object_mut().unwrap().insert(
+                "_revisions".into(),
+                serde_json::json!({"start": pos, "ids": ids}),
+            );
+            let d = Document {
+                id: "doc1".into(),
+                rev: Some(Revision::new(pos, hash.into())),
+                deleted: false,
+                data,
+                attachments: HashMap::new(),
+            };
+            db.bulk_docs(vec![d], BulkDocsOptions::replication())
+                .await
+                .unwrap();
+        }
+
+        // Requesting an internal node on the losing branch with latest=true
+        // must follow THAT branch to 3-ccc, not jump to the global winner
+        // 4-eee.
+        let doc = db
+            .get(
+                "doc1",
+                GetOptions {
+                    rev: Some("2-bbb".into()),
+                    latest: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(doc.rev.unwrap().to_string(), "3-ccc");
+        assert_eq!(doc.data["v"], "ccc");
     }
 
     #[tokio::test]

--- a/crates/rouchdb-adapter-memory/src/lib.rs
+++ b/crates/rouchdb-adapter-memory/src/lib.rs
@@ -1002,18 +1002,17 @@ fn process_doc_new_edits(inner: &mut Inner, doc: Document) -> DocResult {
                     };
                 }
             }
-            (None, Some(_)) => {
-                // Trying to create a doc that already exists (and isn't deleted)
-                if !is_deleted(&stored.rev_tree) {
-                    return DocResult {
-                        ok: false,
-                        id: doc_id,
-                        rev: None,
-                        error: Some("conflict".into()),
-                        reason: Some("Document update conflict".into()),
-                    };
-                }
-                // If winner is deleted, allow creating a new doc at the same ID
+            // Creating a doc that already exists and is not deleted is a
+            // conflict; if the current winner is deleted, fall through and
+            // allow re-creating it at the same id.
+            (None, Some(_)) if !is_deleted(&stored.rev_tree) => {
+                return DocResult {
+                    ok: false,
+                    id: doc_id,
+                    rev: None,
+                    error: Some("conflict".into()),
+                    reason: Some("Document update conflict".into()),
+                };
             }
             _ => {}
         }

--- a/crates/rouchdb-adapter-redb/Cargo.toml
+++ b/crates/rouchdb-adapter-redb/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.4.0" }
 async-trait = "0.1"
 base64 = "0.22"
 md-5 = "0.10"

--- a/crates/rouchdb-adapter-redb/src/lib.rs
+++ b/crates/rouchdb-adapter-redb/src/lib.rs
@@ -218,22 +218,6 @@ impl RedbAdapter {
             write_lock: Arc::new(RwLock::new(())),
         })
     }
-
-    fn read_meta(&self) -> Result<MetaRecord> {
-        let read_txn = self
-            .db
-            .begin_read()
-            .map_err(|e| RouchError::DatabaseError(e.to_string()))?;
-        let table = read_txn
-            .open_table(META_TABLE)
-            .map_err(|e| RouchError::DatabaseError(e.to_string()))?;
-        let guard = table
-            .get("meta")
-            .map_err(|e| RouchError::DatabaseError(e.to_string()))?
-            .ok_or_else(|| RouchError::DatabaseError("missing metadata".into()))?;
-        let meta: MetaRecord = serde_json::from_slice(guard.value())?;
-        Ok(meta)
-    }
 }
 
 fn generate_rev_hash(
@@ -283,17 +267,27 @@ macro_rules! db_err {
 #[async_trait]
 impl Adapter for RedbAdapter {
     async fn info(&self) -> Result<DbInfo> {
-        let meta = self.read_meta()?;
+        // Read metadata and document data from a SINGLE read transaction so
+        // update_seq and the doc snapshot reflect the same committed state.
         let read_txn = db_err!(self.db.begin_read())?;
+        let meta_table = db_err!(read_txn.open_table(META_TABLE))?;
+        let meta: MetaRecord = serde_json::from_slice(
+            db_err!(meta_table.get("meta"))?
+                .ok_or_else(|| RouchError::DatabaseError("missing metadata".into()))?
+                .value(),
+        )?;
         let table = db_err!(read_txn.open_table(DOC_TABLE))?;
 
         let mut doc_count = 0u64;
+        let mut doc_del_count = 0u64;
         let iter = db_err!(table.iter())?;
         for entry in iter {
             let entry = db_err!(entry)?;
             let record: DocRecord = serde_json::from_slice(entry.1.value())?;
             let tree = serialized_to_rev_tree(&record.rev_tree);
-            if !is_deleted(&tree) {
+            if is_deleted(&tree) {
+                doc_del_count += 1;
+            } else {
                 doc_count += 1;
             }
         }
@@ -301,6 +295,7 @@ impl Adapter for RedbAdapter {
         Ok(DbInfo {
             db_name: self.name.clone(),
             doc_count,
+            doc_del_count,
             update_seq: Seq::Num(meta.update_seq),
         })
     }
@@ -326,11 +321,15 @@ impl Adapter for RedbAdapter {
         let key = rev_data_key(id, &target_rev);
         let rev_guard = db_err!(rev_table.get(key.as_str()))?;
 
-        let (data, deleted) = if let Some(guard) = rev_guard {
+        let (data, deleted, att_records) = if let Some(guard) = rev_guard {
             let rd: RevDataRecord = serde_json::from_slice(guard.value())?;
-            (rd.data, rd.deleted)
+            (rd.data, rd.deleted, rd.attachments)
         } else {
-            (serde_json::Value::Object(serde_json::Map::new()), false)
+            (
+                serde_json::Value::Object(serde_json::Map::new()),
+                false,
+                HashMap::new(),
+            )
         };
 
         if deleted && opts.rev.is_none() {
@@ -346,6 +345,21 @@ impl Adapter for RedbAdapter {
             data,
             attachments: HashMap::new(),
         };
+
+        // Surface stored attachment metadata (content type, digest, length) so
+        // callers can read it without a separate attachment fetch.
+        for (name, rec) in att_records {
+            doc.attachments.insert(
+                name,
+                AttachmentMeta {
+                    content_type: rec.content_type,
+                    digest: rec.digest,
+                    length: rec.length,
+                    stub: true,
+                    data: None,
+                },
+            );
+        }
 
         if opts.conflicts {
             let conflicts = collect_conflicts(&tree);
@@ -416,6 +430,7 @@ impl Adapter for RedbAdapter {
         let rev_table = db_err!(read_txn.open_table(REV_DATA_TABLE))?;
 
         let mut rows = Vec::new();
+        let mut total_count = 0u64;
 
         let iter = db_err!(doc_table.iter())?;
         for entry in iter {
@@ -430,23 +445,34 @@ impl Adapter for RedbAdapter {
             };
             let deleted = is_deleted(&tree);
 
+            // total_rows is the count of non-deleted documents in the whole
+            // database, independent of any range / key / skip / limit filters.
+            if !deleted {
+                total_count += 1;
+            }
+
             if deleted && opts.keys.is_none() {
                 continue;
             }
 
-            // Apply key range filters
+            // Apply key range filters (descending flips startkey/endkey meaning)
             if opts.keys.is_none() && opts.key.is_none() {
                 if let Some(ref start) = opts.start_key
-                    && doc_id.as_str() < start.as_str()
+                    && ((!opts.descending && doc_id.as_str() < start.as_str())
+                        || (opts.descending && doc_id.as_str() > start.as_str()))
                 {
                     continue;
                 }
                 if let Some(ref end) = opts.end_key {
                     if opts.inclusive_end {
-                        if doc_id.as_str() > end.as_str() {
+                        if (!opts.descending && doc_id.as_str() > end.as_str())
+                            || (opts.descending && doc_id.as_str() < end.as_str())
+                        {
                             continue;
                         }
-                    } else if doc_id.as_str() >= end.as_str() {
+                    } else if (!opts.descending && doc_id.as_str() >= end.as_str())
+                        || (opts.descending && doc_id.as_str() <= end.as_str())
+                    {
                         continue;
                     }
                 }
@@ -467,16 +493,34 @@ impl Adapter for RedbAdapter {
             let doc_json = if opts.include_docs && !deleted {
                 let rev_str = winner.to_string();
                 let key = rev_data_key(&doc_id, &rev_str);
-                db_err!(rev_table.get(key.as_str()))?.map(|guard| {
-                    let rd: RevDataRecord = serde_json::from_slice(guard.value()).unwrap();
-                    let mut obj = match rd.data {
-                        serde_json::Value::Object(m) => m,
-                        _ => serde_json::Map::new(),
-                    };
-                    obj.insert("_id".into(), serde_json::Value::String(doc_id.clone()));
-                    obj.insert("_rev".into(), serde_json::Value::String(rev_str));
-                    serde_json::Value::Object(obj)
-                })
+                match db_err!(rev_table.get(key.as_str()))? {
+                    Some(guard) => {
+                        let rd: RevDataRecord = serde_json::from_slice(guard.value())?;
+                        let mut obj = match rd.data {
+                            serde_json::Value::Object(m) => m,
+                            _ => serde_json::Map::new(),
+                        };
+                        obj.insert("_id".into(), serde_json::Value::String(doc_id.clone()));
+                        obj.insert("_rev".into(), serde_json::Value::String(rev_str));
+                        // Embed _conflicts when requested, matching the memory
+                        // adapter and CouchDB.
+                        if opts.conflicts {
+                            let conflicts = collect_conflicts(&tree);
+                            if !conflicts.is_empty() {
+                                let conflict_list: Vec<serde_json::Value> = conflicts
+                                    .iter()
+                                    .map(|c| serde_json::Value::String(c.to_string()))
+                                    .collect();
+                                obj.insert(
+                                    "_conflicts".into(),
+                                    serde_json::Value::Array(conflict_list),
+                                );
+                            }
+                        }
+                        Some(serde_json::Value::Object(obj))
+                    }
+                    None => None,
+                }
             } else {
                 None
             };
@@ -496,7 +540,7 @@ impl Adapter for RedbAdapter {
             rows.reverse();
         }
 
-        let total_rows = rows.len() as u64;
+        let total_rows = total_count;
         let skip = opts.skip as usize;
         if skip > 0 {
             rows = rows.into_iter().skip(skip).collect();
@@ -505,8 +549,15 @@ impl Adapter for RedbAdapter {
             rows.truncate(limit as usize);
         }
 
+        // Read update_seq from the SAME read transaction as the doc snapshot
+        // to avoid a TOCTOU inconsistency with a concurrent committed write.
         let update_seq = if opts.update_seq {
-            let meta = self.read_meta()?;
+            let meta_table = db_err!(read_txn.open_table(META_TABLE))?;
+            let meta: MetaRecord = serde_json::from_slice(
+                db_err!(meta_table.get("meta"))?
+                    .ok_or_else(|| RouchError::DatabaseError("missing metadata".into()))?
+                    .value(),
+            )?;
             Some(Seq::Num(meta.update_seq))
         } else {
             None
@@ -528,18 +579,20 @@ impl Adapter for RedbAdapter {
 
         let mut results = Vec::new();
 
-        let start = opts.since.as_num() + 1;
+        let start = opts.since.as_num().saturating_add(1);
         let iter = db_err!(changes_table.range(start..))?;
 
-        let entries: Vec<_> = iter
+        // Propagate deserialization errors instead of panicking on a corrupt
+        // or truncated change record.
+        let entries: Vec<(u64, ChangeRecord)> = iter
             .filter_map(|e| e.ok())
             .map(|e| {
-                (
+                Ok((
                     e.0.value(),
-                    serde_json::from_slice::<ChangeRecord>(e.1.value()).unwrap(),
-                )
+                    serde_json::from_slice::<ChangeRecord>(e.1.value())?,
+                ))
             })
-            .collect();
+            .collect::<Result<Vec<_>>>()?;
 
         let iter: Box<dyn Iterator<Item = &(u64, ChangeRecord)>> = if opts.descending {
             Box::new(entries.iter().rev())
@@ -547,7 +600,13 @@ impl Adapter for RedbAdapter {
             Box::new(entries.iter())
         };
 
+        // Highest sequence inspected, so last_seq advances past a fully
+        // filtered range instead of sticking at `since`.
+        let mut max_scanned: Option<u64> = None;
+
         for (seq, change) in iter {
+            max_scanned = Some(max_scanned.map_or(*seq, |m| m.max(*seq)));
+
             if let Some(ref doc_ids) = opts.doc_ids
                 && !doc_ids.contains(&change.doc_id)
             {
@@ -564,22 +623,25 @@ impl Adapter for RedbAdapter {
 
             let doc = if opts.include_docs && !rev_str.is_empty() {
                 let key = rev_data_key(&change.doc_id, &rev_str);
-                db_err!(rev_table.get(key.as_str()))?.map(|guard| {
-                    let rd: RevDataRecord = serde_json::from_slice(guard.value()).unwrap();
-                    let mut obj = match rd.data {
-                        serde_json::Value::Object(m) => m,
-                        _ => serde_json::Map::new(),
-                    };
-                    obj.insert(
-                        "_id".into(),
-                        serde_json::Value::String(change.doc_id.clone()),
-                    );
-                    obj.insert("_rev".into(), serde_json::Value::String(rev_str.clone()));
-                    if change.deleted {
-                        obj.insert("_deleted".into(), serde_json::Value::Bool(true));
+                match db_err!(rev_table.get(key.as_str()))? {
+                    Some(guard) => {
+                        let rd: RevDataRecord = serde_json::from_slice(guard.value())?;
+                        let mut obj = match rd.data {
+                            serde_json::Value::Object(m) => m,
+                            _ => serde_json::Map::new(),
+                        };
+                        obj.insert(
+                            "_id".into(),
+                            serde_json::Value::String(change.doc_id.clone()),
+                        );
+                        obj.insert("_rev".into(), serde_json::Value::String(rev_str.clone()));
+                        if change.deleted {
+                            obj.insert("_deleted".into(), serde_json::Value::Bool(true));
+                        }
+                        Some(serde_json::Value::Object(obj))
                     }
-                    serde_json::Value::Object(obj)
-                })
+                    None => None,
+                }
             } else {
                 None
             };
@@ -642,6 +704,7 @@ impl Adapter for RedbAdapter {
         let last_seq = results
             .last()
             .map(|r| r.seq.clone())
+            .or_else(|| max_scanned.map(Seq::Num))
             .unwrap_or(opts.since.clone());
 
         Ok(ChangesResponse { results, last_seq })
@@ -1564,6 +1627,74 @@ mod tests {
             .await
             .unwrap();
         assert!(!r3[0].ok);
+    }
+
+    #[tokio::test]
+    async fn all_docs_descending_with_range() {
+        let (_dir, db) = temp_db();
+        for name in ["a", "b", "c", "d"] {
+            db.bulk_docs(
+                vec![Document {
+                    id: name.into(),
+                    rev: None,
+                    deleted: false,
+                    data: serde_json::json!({}),
+                    attachments: HashMap::new(),
+                }],
+                BulkDocsOptions::new(),
+            )
+            .await
+            .unwrap();
+        }
+
+        // descending flips startkey/endkey: startkey="c" is the upper bound,
+        // endkey="b" the lower bound -> expect ["c", "b"].
+        let opts = AllDocsOptions {
+            descending: true,
+            start_key: Some("c".into()),
+            end_key: Some("b".into()),
+            ..AllDocsOptions::new()
+        };
+        let result = db.all_docs(opts).await.unwrap();
+        let ids: Vec<&str> = result.rows.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["c", "b"]);
+        assert_eq!(result.total_rows, 4);
+    }
+
+    #[tokio::test]
+    async fn all_docs_includes_conflicts() {
+        let (_dir, db) = temp_db();
+        // Two conflicting leaves on the same document via replication.
+        for hash in ["bbb", "ccc"] {
+            let mut data = serde_json::json!({ "v": hash });
+            data.as_object_mut().unwrap().insert(
+                "_revisions".into(),
+                serde_json::json!({"start": 2, "ids": [hash, "aaa"]}),
+            );
+            db.bulk_docs(
+                vec![Document {
+                    id: "doc1".into(),
+                    rev: Some(Revision::new(2, hash.into())),
+                    deleted: false,
+                    data,
+                    attachments: HashMap::new(),
+                }],
+                BulkDocsOptions::replication(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let opts = AllDocsOptions {
+            include_docs: true,
+            conflicts: true,
+            ..AllDocsOptions::new()
+        };
+        let result = db.all_docs(opts).await.unwrap();
+        let doc = result.rows[0].doc.as_ref().unwrap();
+        let conflicts = doc["_conflicts"].as_array().expect("_conflicts present");
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0], "2-bbb"); // loser (ccc wins by higher hash)
     }
 
     #[tokio::test]

--- a/crates/rouchdb-adapter-redb/src/lib.rs
+++ b/crates/rouchdb-adapter-redb/src/lib.rs
@@ -1248,16 +1248,16 @@ fn process_doc_new_edits(
                     });
                 }
             }
-            (None, Some(_)) => {
-                if !is_deleted(&tree) {
-                    return Ok(DocResult {
-                        ok: false,
-                        id: doc_id,
-                        rev: None,
-                        error: Some("conflict".into()),
-                        reason: Some("Document update conflict".into()),
-                    });
-                }
+            // Creating a doc that already exists and is not deleted is a
+            // conflict; a deleted winner falls through and may be re-created.
+            (None, Some(_)) if !is_deleted(&tree) => {
+                return Ok(DocResult {
+                    ok: false,
+                    id: doc_id,
+                    rev: None,
+                    error: Some("conflict".into()),
+                    reason: Some("Document update conflict".into()),
+                });
             }
             _ => {}
         }

--- a/crates/rouchdb-changes/Cargo.toml
+++ b/crates/rouchdb-changes/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.4.0" }
 tokio = { version = "1", features = ["sync", "time", "macros", "rt"] }
 tokio-util = "0.7"
 serde_json = "1"

--- a/crates/rouchdb-changes/src/lib.rs
+++ b/crates/rouchdb-changes/src/lib.rs
@@ -33,6 +33,8 @@ pub enum ChangesEvent {
     Paused,
     /// The stream resumed fetching after being paused.
     Active,
+    /// A periodic keep-alive emitted while waiting, per the `heartbeat` option.
+    Heartbeat,
 }
 use rouchdb_core::error::Result;
 
@@ -155,9 +157,12 @@ pub async fn get_changes(
     opts: ChangesStreamOptions,
 ) -> Result<Vec<ChangeEvent>> {
     let filter = opts.filter.clone();
+    let limit = opts.limit;
     let changes_opts = ChangesOptions {
         since: opts.since,
-        limit: opts.limit,
+        // With a filter, the limit applies to POST-filter results, so don't
+        // let the adapter cap the fetch by limit (it would under-deliver).
+        limit: if filter.is_some() { None } else { opts.limit },
         descending: false,
         include_docs: opts.include_docs,
         live: false,
@@ -168,11 +173,14 @@ pub async fn get_changes(
     };
 
     let response = adapter.changes(changes_opts).await?;
-    let results = if let Some(f) = filter {
+    let mut results = if let Some(f) = filter {
         response.results.into_iter().filter(|e| f(e)).collect()
     } else {
         response.results
     };
+    if let Some(l) = limit {
+        results.truncate(l as usize);
+    }
     Ok(results)
 }
 
@@ -273,6 +281,13 @@ impl LiveChangesStream {
                     if self.buffer_idx < self.buffer.len() {
                         let event = self.buffer[self.buffer_idx].clone();
                         self.buffer_idx += 1;
+                        // Apply the user filter here so `limit` (and `count`)
+                        // reflect emitted, not merely scanned, events.
+                        if let Some(ref f) = self.opts.filter
+                            && !f(&event)
+                        {
+                            continue;
+                        }
                         self.count += 1;
                         return Some(event);
                     }
@@ -364,9 +379,10 @@ pub fn live_changes(
     let (tx, rx) = mpsc::channel(64);
     let cancel = CancellationToken::new();
     let cancel_clone = cancel.clone();
-    let filter = opts.filter.clone();
 
     tokio::spawn(async move {
+        // The user filter is applied inside the stream so `limit` counts only
+        // emitted (post-filter) events.
         let mut stream =
             LiveChangesStream::new(adapter, None, ChangesStreamOptions { live: true, ..opts });
 
@@ -375,12 +391,6 @@ pub fn live_changes(
                 change = stream.next_change() => {
                     match change {
                         Some(event) => {
-                            // Apply filter if set
-                            if let Some(ref f) = filter
-                                && !f(&event)
-                            {
-                                continue;
-                            }
                             if tx.send(event).await.is_err() {
                                 break; // Receiver dropped
                             }
@@ -408,13 +418,21 @@ pub fn live_changes_events(
     let (tx, rx) = mpsc::channel(64);
     let cancel = CancellationToken::new();
     let cancel_clone = cancel.clone();
-    let filter = opts.filter.clone();
+    let heartbeat_dur = opts.heartbeat;
 
     tokio::spawn(async move {
+        // The user filter is applied inside the stream so `limit` counts only
+        // emitted (post-filter) events.
         let mut stream =
             LiveChangesStream::new(adapter, None, ChangesStreamOptions { live: true, ..opts });
 
         let mut was_paused = false;
+        // Optional keep-alive ticker; first tick is one interval from now.
+        let mut heartbeat = heartbeat_dur.map(|d| {
+            let mut i = tokio::time::interval_at(tokio::time::Instant::now() + d, d);
+            i.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            i
+        });
 
         loop {
             tokio::select! {
@@ -425,13 +443,6 @@ pub fn live_changes_events(
                             if was_paused {
                                 was_paused = false;
                                 let _ = tx.send(ChangesEvent::Active).await;
-                            }
-
-                            // Apply filter if set
-                            if let Some(ref f) = filter
-                                && !f(&event)
-                            {
-                                continue;
                             }
 
                             if tx.send(ChangesEvent::Change(event)).await.is_err() {
@@ -446,6 +457,12 @@ pub fn live_changes_events(
                             break;
                         }
                     }
+                }
+                _ = async { heartbeat.as_mut().unwrap().tick().await }, if heartbeat.is_some() => {
+                    if tx.send(ChangesEvent::Heartbeat).await.is_err() {
+                        break;
+                    }
+                    continue;
                 }
                 _ = cancel_clone.cancelled() => {
                     let _ = tx.send(ChangesEvent::Complete {
@@ -631,6 +648,39 @@ mod tests {
         assert_eq!(event.id, "b");
 
         handle.cancel();
+    }
+
+    #[tokio::test]
+    async fn limit_counts_post_filter_events() {
+        // 5 docs; a filter that only accepts even-indexed ids; limit 2.
+        // The limit must yield 2 MATCHING events, not stop after scanning 2.
+        let (db, _sender) = setup().await;
+        for i in 0..6 {
+            put_doc(db.as_ref(), &format!("d{}", i), serde_json::json!({"i": i})).await;
+        }
+
+        let filter: ChangesFilter = Arc::new(|e: &ChangeEvent| {
+            // accept d0, d2, d4 (ids ending in an even digit)
+            e.id.trim_start_matches('d')
+                .parse::<u64>()
+                .map(|n| n % 2 == 0)
+                .unwrap_or(false)
+        });
+
+        let events = get_changes(
+            db.as_ref(),
+            ChangesStreamOptions {
+                limit: Some(2),
+                filter: Some(filter),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].id, "d0");
+        assert_eq!(events[1].id, "d2");
     }
 
     #[tokio::test]

--- a/crates/rouchdb-cli/src/main.rs
+++ b/crates/rouchdb-cli/src/main.rs
@@ -461,10 +461,13 @@ async fn run(cli: Cli) -> rouchdb::Result<()> {
             let effective_rev = if rev.is_some() {
                 rev
             } else if force {
-                db.get(&doc_id)
-                    .await
-                    .ok()
-                    .and_then(|doc| doc.rev.map(|r| r.to_string()))
+                // Only a genuinely missing document should fall through to a
+                // create; surface any other error instead of silently creating.
+                match db.get(&doc_id).await {
+                    Ok(doc) => doc.rev.map(|r| r.to_string()),
+                    Err(rouchdb::RouchError::NotFound(_)) => None,
+                    Err(e) => return Err(e),
+                }
             } else {
                 None
             };
@@ -592,6 +595,16 @@ async fn run(cli: Cli) -> rouchdb::Result<()> {
                 }),
                 cli.pretty,
             );
+
+            // Exit non-zero if any document failed, like the other write
+            // commands (put/post/delete).
+            if !errors.is_empty() {
+                return Err(rouchdb::RouchError::BadRequest(format!(
+                    "{} of {} documents failed to import",
+                    errors.len(),
+                    docs.len()
+                )));
+            }
         }
     }
 

--- a/crates/rouchdb-core/src/collation.rs
+++ b/crates/rouchdb-core/src/collation.rs
@@ -44,13 +44,7 @@ pub fn collate(a: &Value, b: &Value) -> Ordering {
     match (a, b) {
         (Value::Null, Value::Null) => Ordering::Equal,
         (Value::Bool(a), Value::Bool(b)) => a.cmp(b),
-        (Value::Number(a), Value::Number(b)) => {
-            let fa = a.as_f64().unwrap_or(0.0);
-            let fb = b.as_f64().unwrap_or(0.0);
-            // total_cmp gives a well-defined ordering for all f64 values
-            // including NaN (which shouldn't appear in JSON but be safe)
-            fa.total_cmp(&fb)
-        }
+        (Value::Number(a), Value::Number(b)) => compare_numbers(a, b),
         (Value::String(a), Value::String(b)) => a.cmp(b),
         (Value::Array(a), Value::Array(b)) => {
             // Element-by-element, shorter arrays sort first
@@ -84,6 +78,32 @@ pub fn collate(a: &Value, b: &Value) -> Ordering {
         }
         _ => Ordering::Equal, // Should be unreachable due to rank check
     }
+}
+
+/// Compare two JSON numbers without losing precision on large integers.
+///
+/// `serde_json::Number` can hold `u64`, `i64`, or `f64`. Converting straight
+/// to `f64` (as a naive implementation does) collapses integers larger than
+/// 2^53 onto the same float, making distinct values compare `Equal` and
+/// breaking Mango `$eq`/range queries. When both operands are integers we
+/// compare them exactly via `i128`; otherwise we fall back to `f64`.
+fn compare_numbers(a: &serde_json::Number, b: &serde_json::Number) -> Ordering {
+    fn as_i128(n: &serde_json::Number) -> Option<i128> {
+        if let Some(i) = n.as_i64() {
+            Some(i as i128)
+        } else {
+            n.as_u64().map(|u| u as i128)
+        }
+    }
+
+    if let (Some(ia), Some(ib)) = (as_i128(a), as_i128(b)) {
+        return ia.cmp(&ib);
+    }
+    let fa = a.as_f64().unwrap_or(0.0);
+    let fb = b.as_f64().unwrap_or(0.0);
+    // total_cmp gives a well-defined ordering for all f64 values including NaN
+    // (which shouldn't appear in JSON but be safe).
+    fa.total_cmp(&fb)
 }
 
 // ---------------------------------------------------------------------------
@@ -260,6 +280,25 @@ mod tests {
         assert_eq!(collate(&json!(0), &json!(1)), Ordering::Less);
         assert_eq!(collate(&json!(1), &json!(2)), Ordering::Less);
         assert_eq!(collate(&json!(1.5), &json!(2)), Ordering::Less);
+    }
+
+    #[test]
+    fn large_integer_precision() {
+        // Distinct integers beyond f64's 2^53 exact range must not collapse
+        // to Equal (regression: naive as_f64 comparison loses precision).
+        let a = json!(9_007_199_254_740_992_i64); // 2^53
+        let b = json!(9_007_199_254_740_993_i64); // 2^53 + 1
+        assert_eq!(collate(&a, &b), Ordering::Less);
+        assert_eq!(collate(&b, &a), Ordering::Greater);
+        assert_eq!(collate(&a, &a), Ordering::Equal);
+
+        // u64 above i64::MAX vs a smaller value.
+        let big = json!(u64::MAX);
+        let small = json!(1_i64);
+        assert_eq!(collate(&small, &big), Ordering::Less);
+
+        // Mixed integer / float still orders correctly.
+        assert_eq!(collate(&json!(2_i64), &json!(1.5)), Ordering::Greater);
     }
 
     #[test]

--- a/crates/rouchdb-core/src/document.rs
+++ b/crates/rouchdb-core/src/document.rs
@@ -43,6 +43,9 @@ impl FromStr for Revision {
         let pos: u64 = pos_str
             .parse()
             .map_err(|_| RouchError::InvalidRev(s.to_string()))?;
+        if hash.is_empty() {
+            return Err(RouchError::InvalidRev(s.to_string()));
+        }
         Ok(Revision {
             pos,
             hash: hash.to_string(),
@@ -185,10 +188,26 @@ impl Document {
             obj.insert("_deleted".into(), serde_json::Value::Bool(true));
         }
 
-        if !self.attachments.is_empty()
-            && let Ok(att_json) = serde_json::to_value(&self.attachments)
-        {
-            obj.insert("_attachments".into(), att_json);
+        if !self.attachments.is_empty() {
+            use base64::Engine;
+            let mut att_map = serde_json::Map::new();
+            for (name, att) in &self.attachments {
+                if let Ok(serde_json::Value::Object(mut m)) = serde_json::to_value(att) {
+                    // Inline attachment bytes must be emitted as a CouchDB
+                    // base64 string, not serde's default numeric byte array.
+                    if let Some(bytes) = &att.data {
+                        m.insert(
+                            "data".into(),
+                            serde_json::Value::String(
+                                base64::engine::general_purpose::STANDARD.encode(bytes),
+                            ),
+                        );
+                        m.insert("stub".into(), serde_json::Value::Bool(false));
+                    }
+                    att_map.insert(name.clone(), serde_json::Value::Object(m));
+                }
+            }
+            obj.insert("_attachments".into(), serde_json::Value::Object(att_map));
         }
 
         serde_json::Value::Object(obj)
@@ -330,6 +349,8 @@ pub struct AllDocsResponse {
 pub struct DbInfo {
     pub db_name: String,
     pub doc_count: u64,
+    #[serde(default)]
+    pub doc_del_count: u64,
     pub update_seq: Seq,
 }
 
@@ -359,7 +380,7 @@ pub enum ChangesStyle {
     /// Default: only the winning revision.
     #[default]
     MainOnly,
-    /// All non-deleted leaf revisions.
+    /// All leaf revisions (including deleted ones), matching CouchDB.
     AllDocs,
 }
 
@@ -520,6 +541,10 @@ pub struct SecurityDocument {
     pub admins: SecurityGroup,
     #[serde(default)]
     pub members: SecurityGroup,
+    /// Arbitrary additional fields CouchDB permits in `_security` are preserved
+    /// so they round-trip instead of being silently dropped.
+    #[serde(flatten, default)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -569,6 +594,39 @@ mod tests {
     fn invalid_revision() {
         assert!("nope".parse::<Revision>().is_err());
         assert!("abc-123".parse::<Revision>().is_err());
+    }
+
+    #[test]
+    fn revision_rejects_empty_hash() {
+        // "{pos}-" with no hash is malformed and must be rejected.
+        assert!("3-".parse::<Revision>().is_err());
+        assert!("1-".parse::<Revision>().is_err());
+    }
+
+    #[test]
+    fn to_json_inline_attachment_is_base64() {
+        let mut attachments = HashMap::new();
+        attachments.insert(
+            "hi.txt".into(),
+            AttachmentMeta {
+                content_type: "text/plain".into(),
+                digest: "md5-abc".into(),
+                length: 3,
+                stub: false,
+                data: Some(b"hi!".to_vec()),
+            },
+        );
+        let doc = Document {
+            id: "doc1".into(),
+            rev: None,
+            deleted: false,
+            data: serde_json::json!({}),
+            attachments,
+        };
+        let json = doc.to_json();
+        // CouchDB requires inline data as a base64 string, not a byte array.
+        assert_eq!(json["_attachments"]["hi.txt"]["data"], "aGkh");
+        assert_eq!(json["_attachments"]["hi.txt"]["stub"], false);
     }
 
     #[test]

--- a/crates/rouchdb-core/src/merge.rs
+++ b/crates/rouchdb-core/src/merge.rs
@@ -325,69 +325,133 @@ pub fn collect_conflicts(tree: &RevTree) -> Vec<Revision> {
 // Stemming (pruning old revisions)
 // ---------------------------------------------------------------------------
 
+/// Maximum number of edges from `node` to its deepest descendant leaf.
+fn max_depth(node: &RevNode) -> u64 {
+    if node.children.is_empty() {
+        return 0;
+    }
+    node.children
+        .iter()
+        .map(|c| 1 + max_depth(c))
+        .max()
+        .unwrap_or(0)
+}
+
 /// Prune revisions beyond `depth` from each leaf. Returns the list of
 /// revision hashes that were removed.
+///
+/// Stemming is applied per branch: when a branch point sits above the cut
+/// line, the common ancestor is dropped and each child subtree is re-rooted
+/// into its own `RevPath`, mirroring `pouchdb-merge`. This is why a `RevTree`
+/// is a list of roots.
 pub fn stem(tree: &mut RevTree, depth: u64) -> Vec<String> {
     let mut stemmed = Vec::new();
-
-    for path in tree.iter_mut() {
-        let s = stem_path(path, depth);
-        stemmed.extend(s);
+    let mut new_roots: RevTree = Vec::new();
+    for path in tree.drain(..) {
+        new_roots.extend(stem_path(path, depth, &mut stemmed));
     }
-
     // Remove any paths that became empty
-    tree.retain(|p| !is_empty_node(&p.tree));
-
+    new_roots.retain(|p| !is_empty_node(&p.tree));
+    *tree = new_roots;
     stemmed
 }
 
-/// Stem a single path, adjusting `pos` if the root gets pruned.
-fn stem_path(path: &mut RevPath, depth: u64) -> Vec<String> {
-    let mut stemmed = Vec::new();
-
-    // Find the maximum depth of any leaf
-    fn max_depth(node: &RevNode) -> u64 {
-        if node.children.is_empty() {
-            return 0;
+/// Stem one rooted path, returning one or more re-rooted paths so every
+/// root-to-leaf chain keeps at most `depth` revisions.
+fn stem_path(path: RevPath, depth: u64, stemmed: &mut Vec<String>) -> Vec<RevPath> {
+    let mut pos = path.pos;
+    let mut node = path.tree;
+    loop {
+        if max_depth(&node) < depth {
+            // The deepest leaf is already within the limit — keep as-is.
+            return vec![RevPath { pos, tree: node }];
         }
-        node.children
-            .iter()
-            .map(|c| 1 + max_depth(c))
-            .max()
-            .unwrap_or(0)
-    }
-
-    let tree_depth = max_depth(&path.tree);
-
-    if tree_depth < depth {
-        return stemmed; // Nothing to stem
-    }
-
-    // We need to remove nodes from the root until the deepest path
-    // is at most `depth` long
-    let levels_to_remove = tree_depth - depth + 1;
-
-    for _ in 0..levels_to_remove {
-        if path.tree.children.len() <= 1 {
-            stemmed.push(path.tree.hash.clone());
-            if let Some(child) = path.tree.children.pop() {
-                path.tree = child;
-                path.pos += 1;
-            } else {
-                // Tree is now empty
-                break;
+        if node.children.len() <= 1 {
+            // Linear prefix: drop the root and descend into the only child.
+            stemmed.push(node.hash.clone());
+            match node.children.pop() {
+                Some(child) => {
+                    node = child;
+                    pos += 1;
+                }
+                None => return vec![], // Tree emptied
             }
         } else {
-            // Can't stem past a branch point
-            break;
+            // Branch point above the cut line: drop it and re-root each child,
+            // stemming each subtree independently.
+            stemmed.push(node.hash.clone());
+            let children = std::mem::take(&mut node.children);
+            let mut out = Vec::new();
+            for child in children {
+                out.extend(stem_path(
+                    RevPath {
+                        pos: pos + 1,
+                        tree: child,
+                    },
+                    depth,
+                    stemmed,
+                ));
+            }
+            return out;
         }
     }
-
-    stemmed
 }
 
 fn is_empty_node(node: &RevNode) -> bool {
     node.hash.is_empty() && node.children.is_empty()
+}
+
+/// Find the winning leaf revision that descends from `(pos, hash)`.
+///
+/// Used for `latest=true`: walk to the tip of the requested rev's branch.
+/// If the rev is itself a leaf it is returned; among multiple descendant
+/// leaves the deterministic winner (non-deleted > higher generation > higher
+/// hash) is chosen. Returns `None` if the rev is not present in the tree.
+pub fn latest_leaf(tree: &RevTree, pos: u64, hash: &str) -> Option<Revision> {
+    fn find_node<'a>(
+        node: &'a RevNode,
+        cur: u64,
+        tpos: u64,
+        thash: &str,
+    ) -> Option<(&'a RevNode, u64)> {
+        if cur == tpos && node.hash == thash {
+            return Some((node, cur));
+        }
+        for c in &node.children {
+            if let Some(found) = find_node(c, cur + 1, tpos, thash) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    fn collect(node: &RevNode, pos: u64, out: &mut Vec<(u64, String, bool)>) {
+        if node.children.is_empty() {
+            out.push((pos, node.hash.clone(), node.opts.deleted));
+        } else {
+            for c in &node.children {
+                collect(c, pos + 1, out);
+            }
+        }
+    }
+
+    for path in tree {
+        if let Some((node, node_pos)) = find_node(&path.tree, path.pos, pos, hash) {
+            let mut leaves: Vec<(u64, String, bool)> = Vec::new();
+            collect(node, node_pos, &mut leaves);
+            // Winner order: non-deleted first, then highest pos, then hash desc.
+            leaves.sort_by(|a, b| {
+                a.2.cmp(&b.2)
+                    .then_with(|| b.0.cmp(&a.0))
+                    .then_with(|| b.1.cmp(&a.1))
+            });
+            return leaves
+                .into_iter()
+                .next()
+                .map(|(p, h, _)| Revision::new(p, h));
+        }
+    }
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -688,7 +752,7 @@ mod tests {
     }
 
     #[test]
-    fn stem_stops_at_branch_point() {
+    fn stem_splits_at_branch_point() {
         // 1-a -> 2-b -> 3-c
         //            -> 3-d
         let mut tree = vec![RevPath {
@@ -696,12 +760,53 @@ mod tests {
             tree: node("a", vec![node("b", vec![leaf("c"), leaf("d")])]),
         }];
 
-        // Even with depth=1, cannot stem past the branch point at 2-b
+        // depth=1 means each leaf keeps a single revision. The shared
+        // ancestors 1-a and 2-b are pruned and each leaf becomes its own root.
         let stemmed = stem(&mut tree, 1);
-        // Stemmed should remove at most 1-a (stop at branch)
-        // Actually, can stem 1-a since 2-b has multiple children
-        // but 2-b cannot be stemmed because it has >1 child
-        assert!(stemmed.len() <= 1);
+        assert_eq!(stemmed.len(), 2); // a and b removed
+        assert!(stemmed.contains(&"a".to_string()));
+        assert!(stemmed.contains(&"b".to_string()));
+
+        assert_eq!(tree.len(), 2); // two separate roots, one per leaf
+        let leaves = collect_leaves(&tree);
+        let hashes: Vec<&str> = leaves.iter().map(|l| l.hash.as_str()).collect();
+        assert!(hashes.contains(&"c"));
+        assert!(hashes.contains(&"d"));
+        assert!(leaves.iter().all(|l| l.pos == 3));
+    }
+
+    #[test]
+    fn stem_prunes_deep_branch_above_cut_line() {
+        // Regression: a conflict branch at generation 1 used to prevent any
+        // stemming, letting the deep branch grow without bound.
+        //   1-a -> 2-b (leaf)
+        //       -> 2-c -> 3-d -> 4-e -> 5-f
+        let mut tree = vec![RevPath {
+            pos: 1,
+            tree: node(
+                "a",
+                vec![
+                    leaf("b"),
+                    node("c", vec![node("d", vec![node("e", vec![leaf("f")])])]),
+                ],
+            ),
+        }];
+
+        let stemmed = stem(&mut tree, 2);
+        // a, c, d are pruned; each leaf keeps at most 2 revisions.
+        assert!(stemmed.contains(&"a".to_string()));
+        assert!(stemmed.contains(&"c".to_string()));
+        assert!(stemmed.contains(&"d".to_string()));
+
+        // Roots become [2-b] and [4-e -> 5-f].
+        assert_eq!(tree.len(), 2);
+        for path in &tree {
+            assert!(max_depth(&path.tree) < 2, "every chain must fit the limit");
+        }
+        // Winner is still 5-f (highest generation across roots).
+        let winner = winning_rev(&tree).unwrap();
+        assert_eq!(winner.pos, 5);
+        assert_eq!(winner.hash, "f");
     }
 
     #[test]
@@ -762,6 +867,36 @@ mod tests {
     fn latest_rev_on_empty_tree() {
         let tree: RevTree = vec![];
         assert!(latest_rev(&tree, 1, "a").is_none());
+    }
+
+    #[test]
+    fn latest_leaf_walks_linear_chain_to_tip() {
+        // 1-a -> 2-b -> 3-c : latest from an internal node returns the leaf.
+        let tree = simple_tree();
+        let rev = latest_leaf(&tree, 1, "a").unwrap();
+        assert_eq!(rev.pos, 3);
+        assert_eq!(rev.hash, "c");
+        // A leaf returns itself.
+        assert_eq!(latest_leaf(&tree, 3, "c").unwrap().hash, "c");
+    }
+
+    #[test]
+    fn latest_leaf_stays_on_requested_branch() {
+        // 1-a -> 2-b -> 3-c   (losing branch)
+        //     -> 2-z -> 3-d -> 4-e   (winning branch by generation)
+        let tree = vec![RevPath {
+            pos: 1,
+            tree: node(
+                "a",
+                vec![
+                    node("b", vec![leaf("c")]),
+                    node("z", vec![node("d", vec![leaf("e")])]),
+                ],
+            ),
+        }];
+        // Global winner is 4-e, but latest from 2-b must stay on its branch.
+        assert_eq!(latest_leaf(&tree, 2, "b").unwrap().to_string(), "3-c");
+        assert_eq!(latest_leaf(&tree, 2, "z").unwrap().to_string(), "4-e");
     }
 
     // --- merge edge cases ---

--- a/crates/rouchdb-query/Cargo.toml
+++ b/crates/rouchdb-query/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.4.0" }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rouchdb-query/src/lib.rs
+++ b/crates/rouchdb-query/src/lib.rs
@@ -13,7 +13,7 @@ pub mod mapreduce;
 pub use mango::{
     BuiltIndex, CreateIndexResponse, ExplainIndex, ExplainResponse, FindOptions, FindResponse,
     IndexDefinition, IndexFields, IndexInfo, SortDirection, SortField, build_index, find,
-    matches_selector,
+    get_nested_field, matches_selector,
 };
 pub use mapreduce::{
     EmittedRow, ReduceFn, StaleOption, ViewQueryOptions, ViewResult, ViewRow, query_view,

--- a/crates/rouchdb-query/src/mango.rs
+++ b/crates/rouchdb-query/src/mango.rs
@@ -342,6 +342,24 @@ fn match_condition(doc: &serde_json::Value, key: &str, condition: &serde_json::V
     }
 }
 
+/// Match a single `$elemMatch` array element against the operand.
+///
+/// CouchDB allows the operand to be either an operator expression applied
+/// directly to the element (e.g. `{"$gt": 80}` over `[50, 85, 60]`), a
+/// sub-document selector (e.g. `{"subject": "math"}` over array-of-objects),
+/// or a bare scalar (implicit `$eq`).
+fn elem_matches(elem: &serde_json::Value, operand: &serde_json::Value) -> bool {
+    if let Some(map) = operand.as_object() {
+        if !map.is_empty() && map.keys().all(|k| k.starts_with('$')) {
+            return map
+                .iter()
+                .all(|(op, sub)| match_operator(Some(elem), op, sub));
+        }
+        return matches_selector(elem, operand);
+    }
+    match_operator(Some(elem), "$eq", operand)
+}
+
 fn match_operator(
     field_value: Option<&serde_json::Value>,
     op: &str,
@@ -430,7 +448,7 @@ fn match_operator(
         }
         "$elemMatch" => field_value.is_some_and(|v| {
             if let Some(arr) = v.as_array() {
-                arr.iter().any(|elem| matches_selector(elem, operand))
+                arr.iter().any(|elem| elem_matches(elem, operand))
             } else {
                 false
             }
@@ -500,7 +518,10 @@ fn match_nor(doc: &serde_json::Value, condition: &serde_json::Value) -> bool {
 }
 
 /// Get a nested field from a JSON value using dot notation.
-fn get_nested_field<'a>(doc: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+pub fn get_nested_field<'a>(
+    doc: &'a serde_json::Value,
+    path: &str,
+) -> Option<&'a serde_json::Value> {
     let mut current = doc;
     for part in path.split('.') {
         match current.get(part) {
@@ -555,6 +576,40 @@ mod tests {
 
     fn doc(json: serde_json::Value) -> serde_json::Value {
         json
+    }
+
+    #[test]
+    fn elem_match_operator_on_scalar_array() {
+        let d = doc(serde_json::json!({"scores": [50, 85, 60]}));
+        // Operator expression applied directly to each element.
+        assert!(matches_selector(
+            &d,
+            &serde_json::json!({"scores": {"$elemMatch": {"$gt": 80}}})
+        ));
+        assert!(!matches_selector(
+            &d,
+            &serde_json::json!({"scores": {"$elemMatch": {"$gt": 90}}})
+        ));
+        // Bare scalar operand -> implicit $eq against each element.
+        assert!(matches_selector(
+            &d,
+            &serde_json::json!({"scores": {"$elemMatch": 85}})
+        ));
+    }
+
+    #[test]
+    fn elem_match_subdocument_array() {
+        let d = doc(serde_json::json!({
+            "items": [{"subject": "math", "score": 90}, {"subject": "art", "score": 70}]
+        }));
+        assert!(matches_selector(
+            &d,
+            &serde_json::json!({"items": {"$elemMatch": {"subject": "math"}}})
+        ));
+        assert!(!matches_selector(
+            &d,
+            &serde_json::json!({"items": {"$elemMatch": {"subject": "history"}}})
+        ));
     }
 
     // --- Basic matching ---

--- a/crates/rouchdb-query/src/mapreduce.rs
+++ b/crates/rouchdb-query/src/mapreduce.rs
@@ -168,8 +168,15 @@ pub async fn query_view(
     if opts.reduce
         && let Some(reduce) = reduce_fn
     {
-        let rows = if opts.group || opts.group_level.is_some() {
+        // group_level == Some(0) means a single global group (no grouping),
+        // matching CouchDB where group_level overrides group.
+        let grouped = opts.group_level.map(|l| l > 0).unwrap_or(opts.group);
+        let rows = if grouped {
             group_reduce(&emitted, reduce, opts.group_level)
+        } else if emitted.is_empty() {
+            // An empty reduce yields no rows (CouchDB returns {"rows":[]}),
+            // not a spurious zero row.
+            Vec::new()
         } else {
             let keys: Vec<serde_json::Value> = emitted.iter().map(|r| r.key.clone()).collect();
             let values: Vec<serde_json::Value> = emitted.iter().map(|r| r.value.clone()).collect();
@@ -182,9 +189,18 @@ pub async fn query_view(
             }]
         };
 
+        // Apply skip/limit to the reduced/grouped rows as well.
+        let reduced_total = rows.len() as u64;
+        let skip = opts.skip as usize;
+        let rows: Vec<ViewRow> = rows
+            .into_iter()
+            .skip(skip)
+            .take(opts.limit.unwrap_or(u64::MAX) as usize)
+            .collect();
+
         return Ok(ViewResult {
-            total_rows: rows.len() as u64,
-            offset: 0,
+            total_rows: reduced_total,
+            offset: opts.skip,
             rows,
         });
     }
@@ -409,6 +425,56 @@ mod tests {
         assert_eq!(result.rows[0].key, "Alice");
         assert_eq!(result.rows[1].key, "Bob");
         assert_eq!(result.rows[2].key, "Charlie");
+    }
+
+    #[tokio::test]
+    async fn reduce_group_level_zero_is_global() {
+        let db = setup_db().await;
+        let result = query_view(
+            &db,
+            &|doc| {
+                let city = doc.get("city").cloned().unwrap_or(serde_json::Value::Null);
+                vec![(city, serde_json::json!(1))]
+            },
+            Some(&ReduceFn::Count),
+            ViewQueryOptions {
+                reduce: true,
+                group_level: Some(0),
+                ..ViewQueryOptions::new()
+            },
+        )
+        .await
+        .unwrap();
+        // group_level=0 collapses everything into one global group.
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0].value, serde_json::json!(3));
+    }
+
+    #[tokio::test]
+    async fn reduce_grouped_honors_skip_and_limit() {
+        let db = setup_db().await;
+        let result = query_view(
+            &db,
+            &|doc| {
+                let city = doc.get("city").cloned().unwrap_or(serde_json::Value::Null);
+                vec![(city, serde_json::json!(1))]
+            },
+            Some(&ReduceFn::Count),
+            ViewQueryOptions {
+                reduce: true,
+                group: true,
+                skip: 1,
+                limit: Some(1),
+                ..ViewQueryOptions::new()
+            },
+        )
+        .await
+        .unwrap();
+        // Groups sorted by key: "LA"(1), "NYC"(2). skip 1 -> NYC; limit 1.
+        assert_eq!(result.total_rows, 2);
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0].key, "NYC");
+        assert_eq!(result.rows[0].value, serde_json::json!(2));
     }
 
     #[tokio::test]

--- a/crates/rouchdb-replication/Cargo.toml
+++ b/crates/rouchdb-replication/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
-rouchdb-query = { path = "../rouchdb-query", version = "0.3.2" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.4.0" }
+rouchdb-query = { path = "../rouchdb-query", version = "0.4.0" }
 md-5 = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rouchdb-replication/src/checkpoint.rs
+++ b/crates/rouchdb-replication/src/checkpoint.rs
@@ -3,11 +3,17 @@ use serde::{Deserialize, Serialize};
 
 use rouchdb_core::adapter::Adapter;
 use rouchdb_core::document::Seq;
-use rouchdb_core::error::Result;
+use rouchdb_core::error::{Result, RouchError};
+
+/// Maximum number of history entries to retain per checkpoint.
+const MAX_HISTORY: usize = 50;
 
 /// A checkpoint document stored as `_local/{replication_id}`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckpointDoc {
+    /// The `_local` doc revision, round-tripped so CouchDB updates don't 409.
+    #[serde(rename = "_rev", default, skip_serializing_if = "Option::is_none")]
+    pub rev: Option<String>,
     pub last_seq: Seq,
     pub session_id: String,
     pub version: u32,
@@ -29,8 +35,12 @@ pub struct Checkpointer {
 
 impl Checkpointer {
     /// Create a new checkpointer for a replication between source and target.
-    pub fn new(source_id: &str, target_id: &str) -> Self {
-        let replication_id = generate_replication_id(source_id, target_id);
+    ///
+    /// `filter_fingerprint` is a stable representation of the active filter so
+    /// that filtered and unfiltered replications between the same pair of
+    /// databases use distinct checkpoints (CouchDB protocol requirement).
+    pub fn new(source_id: &str, target_id: &str, filter_fingerprint: &str) -> Self {
+        let replication_id = generate_replication_id(source_id, target_id, filter_fingerprint);
         let session_id = uuid::Uuid::new_v4().to_string();
         Self {
             replication_id,
@@ -45,12 +55,23 @@ impl Checkpointer {
     /// Read the checkpoint from both source and target, and find the last
     /// common sequence number.
     pub async fn read_checkpoint(&self, source: &dyn Adapter, target: &dyn Adapter) -> Result<Seq> {
-        let source_cp = self.read_from(source).await;
-        let target_cp = self.read_from(target).await;
+        // Only a missing checkpoint means "start from the beginning"; any other
+        // error (auth/network/corruption) must be surfaced rather than silently
+        // re-replicating from scratch.
+        let to_opt = |r: Result<CheckpointDoc>| -> Result<Option<CheckpointDoc>> {
+            match r {
+                Ok(doc) => Ok(Some(doc)),
+                Err(RouchError::NotFound(_)) => Ok(None),
+                Err(e) => Err(e),
+            }
+        };
+
+        let source_cp = to_opt(self.read_from(source).await)?;
+        let target_cp = to_opt(self.read_from(target).await)?;
 
         match (source_cp, target_cp) {
-            (Ok(s), Ok(t)) => Ok(compare_checkpoints(&s, &t)),
-            _ => Ok(Seq::zero()), // No checkpoint found, start from beginning
+            (Some(s), Some(t)) => Ok(compare_checkpoints(&s, &t)),
+            _ => Ok(Seq::zero()), // at least one side has never been checkpointed
         }
     }
 
@@ -61,17 +82,54 @@ impl Checkpointer {
         target: &dyn Adapter,
         last_seq: Seq,
     ) -> Result<()> {
-        let doc = self.build_checkpoint_doc(last_seq);
-        let json = serde_json::to_value(&doc)?;
+        // Carry forward existing history so cross-session divergence recovery
+        // works (each side keeps its own _rev, so write them independently).
+        let prior_history = self
+            .read_from(source)
+            .await
+            .map(|cp| cp.history)
+            .unwrap_or_default();
 
-        // Write to both sides — fail if either side fails to keep them in sync
-        let source_result = source.put_local(&self.replication_id, json.clone()).await;
-        let target_result = target.put_local(&self.replication_id, json).await;
+        self.write_one(source, last_seq.clone(), &prior_history)
+            .await?;
+        self.write_one(target, last_seq, &prior_history).await?;
+        Ok(())
+    }
 
-        match (source_result, target_result) {
-            (Ok(()), Ok(())) => Ok(()),
-            (Err(e), _) | (_, Err(e)) => Err(e),
+    /// Write the checkpoint to one side, injecting its current `_rev` and
+    /// retrying once on conflict (required for CouchDB `_local` updates).
+    async fn write_one(
+        &self,
+        adapter: &dyn Adapter,
+        last_seq: Seq,
+        prior_history: &[CheckpointHistory],
+    ) -> Result<()> {
+        let current_rev = self.current_rev(adapter).await;
+        let mut doc = self.build_checkpoint_doc(last_seq, prior_history.to_vec());
+        doc.rev = current_rev;
+
+        match adapter
+            .put_local(&self.replication_id, serde_json::to_value(&doc)?)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(RouchError::Conflict) => {
+                // Re-fetch the current rev and retry once.
+                doc.rev = self.current_rev(adapter).await;
+                adapter
+                    .put_local(&self.replication_id, serde_json::to_value(&doc)?)
+                    .await
+            }
+            Err(e) => Err(e),
         }
+    }
+
+    async fn current_rev(&self, adapter: &dyn Adapter) -> Option<String> {
+        adapter
+            .get_local(&self.replication_id)
+            .await
+            .ok()
+            .and_then(|json| json.get("_rev").and_then(|v| v.as_str().map(String::from)))
     }
 
     async fn read_from(&self, adapter: &dyn Adapter) -> Result<CheckpointDoc> {
@@ -80,28 +138,73 @@ impl Checkpointer {
         Ok(doc)
     }
 
-    fn build_checkpoint_doc(&self, last_seq: Seq) -> CheckpointDoc {
-        CheckpointDoc {
+    fn build_checkpoint_doc(
+        &self,
+        last_seq: Seq,
+        mut prior_history: Vec<CheckpointHistory>,
+    ) -> CheckpointDoc {
+        // Prepend the current session entry, dropping any stale entry for this
+        // same session, and cap the total length.
+        prior_history.retain(|h| h.session_id != self.session_id);
+        let mut history = Vec::with_capacity(prior_history.len() + 1);
+        history.push(CheckpointHistory {
             last_seq: last_seq.clone(),
+            session_id: self.session_id.clone(),
+        });
+        history.extend(prior_history);
+        history.truncate(MAX_HISTORY);
+
+        CheckpointDoc {
+            rev: None,
+            last_seq,
             session_id: self.session_id.clone(),
             version: 1,
             replicator: "rouchdb".into(),
-            history: vec![CheckpointHistory {
-                last_seq,
-                session_id: self.session_id.clone(),
-            }],
+            history,
         }
     }
 }
 
-/// Generate a deterministic replication ID from source and target identifiers.
-fn generate_replication_id(source_id: &str, target_id: &str) -> String {
+/// Generate a deterministic replication ID from source/target identifiers and
+/// a filter fingerprint, so distinct filters never share a checkpoint.
+fn generate_replication_id(source_id: &str, target_id: &str, filter_fingerprint: &str) -> String {
     let mut hasher = Md5::new();
     hasher.update(source_id.as_bytes());
+    hasher.update(b"\0");
     hasher.update(target_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(filter_fingerprint.as_bytes());
     let hash = format!("{:x}", hasher.finalize());
     // Replace chars that are special in CouchDB URLs
     hash.replace('/', ".").replace('+', "_")
+}
+
+/// Pick the conservative common sequence between two checkpoints.
+///
+/// Opaque CouchDB string sequences (`"42-g1AAA..."`) cannot be reliably
+/// ordered by their numeric prefix, so short-circuit on equality and only
+/// trust numeric ordering for genuinely numeric sequences; otherwise fall back
+/// to the numeric-min (a harmless re-scan, since replication is idempotent).
+fn pick_common(a: &Seq, b: &Seq) -> Seq {
+    if a == b {
+        return a.clone();
+    }
+    match (a, b) {
+        (Seq::Num(x), Seq::Num(y)) => {
+            if x <= y {
+                a.clone()
+            } else {
+                b.clone()
+            }
+        }
+        _ => {
+            if a.as_num() <= b.as_num() {
+                a.clone()
+            } else {
+                b.clone()
+            }
+        }
+    }
 }
 
 /// Compare source and target checkpoints to find the last common sequence.
@@ -111,22 +214,14 @@ fn generate_replication_id(source_id: &str, target_id: &str) -> String {
 fn compare_checkpoints(source: &CheckpointDoc, target: &CheckpointDoc) -> Seq {
     // If sessions match, use the sequence directly
     if source.session_id == target.session_id {
-        return if source.last_seq.as_num() <= target.last_seq.as_num() {
-            source.last_seq.clone()
-        } else {
-            target.last_seq.clone()
-        };
+        return pick_common(&source.last_seq, &target.last_seq);
     }
 
     // Walk through histories to find a common session
     for sh in &source.history {
         for th in &target.history {
             if sh.session_id == th.session_id {
-                return if sh.last_seq.as_num() <= th.last_seq.as_num() {
-                    sh.last_seq.clone()
-                } else {
-                    th.last_seq.clone()
-                };
+                return pick_common(&sh.last_seq, &th.last_seq);
             }
         }
     }
@@ -139,82 +234,68 @@ fn compare_checkpoints(source: &CheckpointDoc, target: &CheckpointDoc) -> Seq {
 mod tests {
     use super::*;
 
+    fn cp(last_seq: u64, session: &str, history: Vec<CheckpointHistory>) -> CheckpointDoc {
+        CheckpointDoc {
+            rev: None,
+            last_seq: Seq::Num(last_seq),
+            session_id: session.into(),
+            version: 1,
+            replicator: "rouchdb".into(),
+            history,
+        }
+    }
+
+    fn hist(last_seq: u64, session: &str) -> CheckpointHistory {
+        CheckpointHistory {
+            last_seq: Seq::Num(last_seq),
+            session_id: session.into(),
+        }
+    }
+
     #[test]
     fn replication_id_deterministic() {
-        let id1 = generate_replication_id("source_a", "target_b");
-        let id2 = generate_replication_id("source_a", "target_b");
+        let id1 = generate_replication_id("source_a", "target_b", "nofilter");
+        let id2 = generate_replication_id("source_a", "target_b", "nofilter");
         assert_eq!(id1, id2);
 
-        let id3 = generate_replication_id("source_a", "target_c");
+        let id3 = generate_replication_id("source_a", "target_c", "nofilter");
         assert_ne!(id1, id3);
+
+        // Different filters must yield different replication ids.
+        let id4 = generate_replication_id("source_a", "target_b", "docids:a,b");
+        assert_ne!(id1, id4);
     }
 
     #[test]
     fn compare_same_session() {
-        let cp = CheckpointDoc {
-            last_seq: Seq::Num(42),
-            session_id: "sess1".into(),
-            version: 1,
-            replicator: "rouchdb".into(),
-            history: vec![],
-        };
-        assert_eq!(compare_checkpoints(&cp, &cp).as_num(), 42);
+        let c = cp(42, "sess1", vec![]);
+        assert_eq!(compare_checkpoints(&c, &c).as_num(), 42);
     }
 
     #[test]
     fn compare_different_session_with_history() {
-        let source = CheckpointDoc {
-            last_seq: Seq::Num(50),
-            session_id: "sess2".into(),
-            version: 1,
-            replicator: "rouchdb".into(),
-            history: vec![
-                CheckpointHistory {
-                    last_seq: Seq::Num(50),
-                    session_id: "sess2".into(),
-                },
-                CheckpointHistory {
-                    last_seq: Seq::Num(30),
-                    session_id: "sess1".into(),
-                },
-            ],
-        };
-        let target = CheckpointDoc {
-            last_seq: Seq::Num(40),
-            session_id: "sess3".into(),
-            version: 1,
-            replicator: "rouchdb".into(),
-            history: vec![
-                CheckpointHistory {
-                    last_seq: Seq::Num(40),
-                    session_id: "sess3".into(),
-                },
-                CheckpointHistory {
-                    last_seq: Seq::Num(30),
-                    session_id: "sess1".into(),
-                },
-            ],
-        };
+        let source = cp(50, "sess2", vec![hist(50, "sess2"), hist(30, "sess1")]);
+        let target = cp(40, "sess3", vec![hist(40, "sess3"), hist(30, "sess1")]);
         // Common session "sess1" at seq 30
         assert_eq!(compare_checkpoints(&source, &target).as_num(), 30);
     }
 
     #[test]
     fn compare_no_common_session() {
-        let source = CheckpointDoc {
-            last_seq: Seq::Num(50),
-            session_id: "a".into(),
-            version: 1,
-            replicator: "rouchdb".into(),
-            history: vec![],
-        };
-        let target = CheckpointDoc {
-            last_seq: Seq::Num(40),
-            session_id: "b".into(),
-            version: 1,
-            replicator: "rouchdb".into(),
-            history: vec![],
-        };
+        let source = cp(50, "a", vec![]);
+        let target = cp(40, "b", vec![]);
         assert_eq!(compare_checkpoints(&source, &target).as_num(), 0);
+    }
+
+    #[test]
+    fn pick_common_handles_opaque_seqs() {
+        // Equal opaque seqs -> that seq.
+        let a = Seq::Str("5-abc".into());
+        assert_eq!(pick_common(&a, &a), a);
+        // Distinct opaque seqs sharing a numeric prefix don't collapse to a
+        // spurious "equal"; a deterministic side is chosen.
+        let b = Seq::Str("5-xyz".into());
+        let picked = pick_common(&a, &b);
+        assert!(picked == a || picked == b);
     }
 }

--- a/crates/rouchdb-replication/src/protocol.rs
+++ b/crates/rouchdb-replication/src/protocol.rs
@@ -92,6 +92,23 @@ pub enum ReplicationEvent {
     Error(String),
 }
 
+/// Build a stable fingerprint of the active filter for the replication ID,
+/// so filtered and unfiltered replications use distinct checkpoints.
+fn filter_fingerprint(filter: &Option<ReplicationFilter>) -> String {
+    match filter {
+        None => "nofilter".to_string(),
+        Some(ReplicationFilter::DocIds(ids)) => {
+            let mut sorted = ids.clone();
+            sorted.sort();
+            format!("docids:{}", sorted.join("\u{0}"))
+        }
+        Some(ReplicationFilter::Selector(sel)) => format!("selector:{}", sel),
+        // A custom closure cannot be fingerprinted deterministically; distinct
+        // custom filters between the same pair therefore share a checkpoint.
+        Some(ReplicationFilter::Custom(_)) => "custom".to_string(),
+    }
+}
+
 /// Run a one-shot replication from source to target.
 ///
 /// Implements the CouchDB replication protocol:
@@ -109,7 +126,11 @@ pub async fn replicate(
     let source_info = source.info().await?;
     let target_info = target.info().await?;
 
-    let checkpointer = Checkpointer::new(&source_info.db_name, &target_info.db_name);
+    let checkpointer = Checkpointer::new(
+        &source_info.db_name,
+        &target_info.db_name,
+        &filter_fingerprint(&opts.filter),
+    );
 
     // Step 1: Read checkpoint (or use override)
     let since = if let Some(ref override_since) = opts.since {
@@ -200,12 +221,16 @@ pub async fn replicate(
 
         // Step 5: Write to target with new_edits=false
         let mut docs_to_write: Vec<Document> = Vec::new();
+        let mut batch_failed = false;
         for result in &bulk_get_response.results {
             for doc in &result.docs {
                 if let Some(ref json) = doc.ok {
                     match Document::from_json(json.clone()) {
                         Ok(document) => docs_to_write.push(document),
-                        Err(e) => errors.push(format!("parse error for {}: {}", result.id, e)),
+                        Err(e) => {
+                            errors.push(format!("parse error for {}: {}", result.id, e));
+                            batch_failed = true;
+                        }
                     }
                 }
             }
@@ -217,7 +242,6 @@ pub async fn replicate(
         }
 
         if !docs_to_write.is_empty() {
-            let write_count = docs_to_write.len() as u64;
             let write_results = target
                 .bulk_docs(docs_to_write, BulkDocsOptions::replication())
                 .await?;
@@ -229,10 +253,19 @@ pub async fn replicate(
                         wr.id,
                         wr.reason.as_deref().unwrap_or("unknown")
                     ));
+                    batch_failed = true;
                 }
             }
 
-            total_docs_written += write_count;
+            // Count only docs that were actually persisted.
+            total_docs_written += write_results.iter().filter(|wr| wr.ok).count() as u64;
+        }
+
+        // Do not advance the checkpoint past a batch that had any parse or
+        // write failure; stop so the next run retries from the un-advanced
+        // sequence rather than silently losing those docs.
+        if batch_failed {
+            break;
         }
 
         // Step 6: Save checkpoint (if enabled)
@@ -268,10 +301,27 @@ pub async fn replicate_with_events(
     opts: ReplicationOptions,
     events_tx: mpsc::Sender<ReplicationEvent>,
 ) -> Result<ReplicationResult> {
+    replicate_with_events_inner(source, target, opts, events_tx, false).await
+}
+
+/// Inner driver shared by the one-shot and live paths. `suppress_complete`
+/// lets the live loop withhold the per-run `Complete` so only one terminal
+/// `Complete` is emitted when the whole live replication ends.
+async fn replicate_with_events_inner(
+    source: &dyn Adapter,
+    target: &dyn Adapter,
+    opts: ReplicationOptions,
+    events_tx: mpsc::Sender<ReplicationEvent>,
+    suppress_complete: bool,
+) -> Result<ReplicationResult> {
     let source_info = source.info().await?;
     let target_info = target.info().await?;
 
-    let checkpointer = Checkpointer::new(&source_info.db_name, &target_info.db_name);
+    let checkpointer = Checkpointer::new(
+        &source_info.db_name,
+        &target_info.db_name,
+        &filter_fingerprint(&opts.filter),
+    );
 
     let since = if let Some(ref override_since) = opts.since {
         override_since.clone()
@@ -356,12 +406,16 @@ pub async fn replicate_with_events(
         let bulk_get_response = source.bulk_get(bulk_get_items).await?;
 
         let mut docs_to_write: Vec<Document> = Vec::new();
+        let mut batch_failed = false;
         for result in &bulk_get_response.results {
             for doc in &result.docs {
                 if let Some(ref json) = doc.ok {
                     match Document::from_json(json.clone()) {
                         Ok(document) => docs_to_write.push(document),
-                        Err(e) => errors.push(format!("parse error for {}: {}", result.id, e)),
+                        Err(e) => {
+                            errors.push(format!("parse error for {}: {}", result.id, e));
+                            batch_failed = true;
+                        }
                     }
                 }
             }
@@ -372,7 +426,6 @@ pub async fn replicate_with_events(
         }
 
         if !docs_to_write.is_empty() {
-            let write_count = docs_to_write.len() as u64;
             let write_results = target
                 .bulk_docs(docs_to_write, BulkDocsOptions::replication())
                 .await?;
@@ -384,10 +437,11 @@ pub async fn replicate_with_events(
                         wr.id,
                         wr.reason.as_deref().unwrap_or("unknown")
                     ));
+                    batch_failed = true;
                 }
             }
 
-            total_docs_written += write_count;
+            total_docs_written += write_results.iter().filter(|wr| wr.ok).count() as u64;
         }
 
         // Emit change event
@@ -396,6 +450,11 @@ pub async fn replicate_with_events(
                 docs_read: total_docs_read,
             })
             .await;
+
+        // Do not advance past a batch with parse/write failures.
+        if batch_failed {
+            break;
+        }
 
         current_seq = batch_last_seq;
         if opts.checkpoint {
@@ -417,9 +476,11 @@ pub async fn replicate_with_events(
         last_seq: current_seq,
     };
 
-    let _ = events_tx
-        .send(ReplicationEvent::Complete(result.clone()))
-        .await;
+    if !suppress_complete {
+        let _ = events_tx
+            .send(ReplicationEvent::Complete(result.clone()))
+            .await;
+    }
 
     Ok(result)
 }
@@ -446,8 +507,11 @@ pub fn replicate_live(
 
     tokio::spawn(async move {
         let mut attempt: u32 = 0;
+        // Track the last successful result so a single terminal Complete can
+        // be emitted when the live loop finally exits.
+        let mut last_result: Option<ReplicationResult> = None;
 
-        loop {
+        'live: loop {
             // Clone the filter for each iteration so Selector and Custom
             // filters remain active across the entire live replication.
             let one_shot_opts = ReplicationOptions {
@@ -462,9 +526,15 @@ pub fn replicate_live(
                 checkpoint: opts.checkpoint,
             };
 
-            let result =
-                replicate_with_events(source.as_ref(), target.as_ref(), one_shot_opts, tx.clone())
-                    .await;
+            // Suppress the per-run Complete; the live loop emits one at the end.
+            let result = replicate_with_events_inner(
+                source.as_ref(),
+                target.as_ref(),
+                one_shot_opts,
+                tx.clone(),
+                true,
+            )
+            .await;
 
             match result {
                 Ok(r) => {
@@ -473,6 +543,7 @@ pub fn replicate_live(
                         // No changes — emit Paused and wait
                         let _ = tx.send(ReplicationEvent::Paused).await;
                     }
+                    last_result = Some(r);
                 }
                 Err(e) => {
                     let _ = tx.send(ReplicationEvent::Error(e.to_string())).await;
@@ -486,11 +557,11 @@ pub fn replicate_live(
                             Duration::from_secs(secs)
                         };
                         tokio::select! {
-                            _ = tokio::time::sleep(delay) => continue,
-                            _ = cancel_clone.cancelled() => break,
+                            _ = tokio::time::sleep(delay) => continue 'live,
+                            _ = cancel_clone.cancelled() => break 'live,
                         }
                     } else {
-                        break;
+                        break 'live;
                     }
                 }
             }
@@ -498,8 +569,13 @@ pub fn replicate_live(
             // Wait for poll_interval or cancellation
             tokio::select! {
                 _ = tokio::time::sleep(poll_interval) => {},
-                _ = cancel_clone.cancelled() => break,
+                _ = cancel_clone.cancelled() => break 'live,
             }
+        }
+
+        // Emit a single terminal Complete on exit.
+        if let Some(result) = last_result {
+            let _ = tx.send(ReplicationEvent::Complete(result)).await;
         }
     });
 
@@ -559,6 +635,44 @@ mod tests {
         assert!(result.ok);
         assert_eq!(result.docs_read, 0);
         assert_eq!(result.docs_written, 0);
+    }
+
+    #[tokio::test]
+    async fn replicate_carries_attachments() {
+        let source = MemoryAdapter::new("source");
+        let target = MemoryAdapter::new("target");
+
+        // Create a doc on the source and attach some bytes.
+        let r = source
+            .bulk_docs(
+                vec![Document {
+                    id: "doc1".into(),
+                    rev: None,
+                    deleted: false,
+                    data: serde_json::json!({"v": 1}),
+                    attachments: HashMap::new(),
+                }],
+                BulkDocsOptions::new(),
+            )
+            .await
+            .unwrap();
+        let rev1 = r[0].rev.clone().unwrap();
+        source
+            .put_attachment("doc1", "hi.txt", &rev1, b"hi!".to_vec(), "text/plain")
+            .await
+            .unwrap();
+
+        let result = replicate(&source, &target, ReplicationOptions::default())
+            .await
+            .unwrap();
+        assert!(result.ok);
+
+        // The attachment bytes must be retrievable on the target.
+        let bytes = target
+            .get_attachment("doc1", "hi.txt", GetAttachmentOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(bytes, b"hi!");
     }
 
     #[tokio::test]

--- a/crates/rouchdb-server/Cargo.toml
+++ b/crates/rouchdb-server/Cargo.toml
@@ -12,8 +12,8 @@ name = "rouchdb-server"
 path = "src/main.rs"
 
 [dependencies]
-rouchdb = { path = "../rouchdb", version = "0.3.2" }
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
+rouchdb = { path = "../rouchdb", version = "0.4.0" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.4.0" }
 clap = { version = "4", features = ["derive"] }
 axum = "0.8"
 tower-http = { version = "0.6", features = ["cors"] }

--- a/crates/rouchdb-server/src/routes/attachment.rs
+++ b/crates/rouchdb-server/src/routes/attachment.rs
@@ -30,10 +30,24 @@ pub async fn get_attachment(
 
     let data = state.db.get_attachment(&docid, &attname).await?;
 
-    // Try to guess content type from the attachment name
-    let content_type = mime_guess::from_path(&attname)
-        .first_or_octet_stream()
-        .to_string();
+    // Prefer the content type stored with the attachment; fall back to a guess
+    // from the name only when it is unavailable.
+    let content_type = state
+        .db
+        .get(&docid)
+        .await
+        .ok()
+        .and_then(|doc| {
+            doc.attachments
+                .get(&attname)
+                .map(|m| m.content_type.clone())
+        })
+        .filter(|ct| !ct.is_empty())
+        .unwrap_or_else(|| {
+            mime_guess::from_path(&attname)
+                .first_or_octet_stream()
+                .to_string()
+        });
 
     Ok((StatusCode::OK, [("content-type", content_type)], data).into_response())
 }

--- a/crates/rouchdb-server/src/routes/changes.rs
+++ b/crates/rouchdb-server/src/routes/changes.rs
@@ -34,19 +34,22 @@ fn validate_db(db: &str, state: &AppState) -> Result<(), AppError> {
     Ok(())
 }
 
-fn parse_since(since: Option<String>) -> Seq {
+/// Resolve the `since` query value to a concrete sequence.
+///
+/// CouchDB's `since=now` means "the database's current update_seq", so resolve
+/// it against `info()` rather than fabricating `u64::MAX` (which would overflow
+/// the adapters' `since + 1` arithmetic).
+async fn resolve_since(state: &AppState, since: Option<String>) -> Result<Seq, AppError> {
     match since {
-        None => Seq::from(0u64),
+        None => Ok(Seq::from(0u64)),
         Some(s) => {
             if s == "now" {
-                // "now" means latest — use a very large number; the adapter
-                // will clamp to the actual last_seq.
-                Seq::from(u64::MAX)
+                Ok(state.db.info().await?.update_seq)
             } else if let Ok(n) = s.parse::<u64>() {
-                Seq::from(n)
+                Ok(Seq::from(n))
             } else {
                 // CouchDB string seqs — pass through
-                Seq::Str(s)
+                Ok(Seq::Str(s))
             }
         }
     }
@@ -66,7 +69,7 @@ pub async fn get_changes(
     };
 
     let opts = ChangesOptions {
-        since: parse_since(query.since),
+        since: resolve_since(&state, query.since).await?,
         limit: query.limit,
         descending: query.descending.unwrap_or(false),
         include_docs: query.include_docs.unwrap_or(false),
@@ -116,7 +119,7 @@ pub async fn post_changes(
         .or_else(|| body.get("since").and_then(|v| v.as_str()).map(String::from));
 
     let opts = ChangesOptions {
-        since: parse_since(since),
+        since: resolve_since(&state, since).await?,
         limit: query
             .limit
             .or_else(|| body.get("limit").and_then(|v| v.as_u64())),

--- a/crates/rouchdb-server/src/routes/database.rs
+++ b/crates/rouchdb-server/src/routes/database.rs
@@ -20,7 +20,7 @@ pub async fn get_db_info(
     Ok(Json(serde_json::json!({
         "db_name": info.db_name,
         "doc_count": info.doc_count,
-        "doc_del_count": 0,
+        "doc_del_count": info.doc_del_count,
         "update_seq": info.update_seq,
         "purge_seq": 0,
         "compact_running": false,
@@ -40,7 +40,11 @@ pub async fn get_db_info(
     })))
 }
 
-/// PUT /{db} — stub: returns 201 if name matches (already exists).
+/// PUT /{db} — create a database.
+///
+/// In single-db mode the database is created at startup, so a PUT for the
+/// matching name always targets an existing database: return 412 file_exists,
+/// matching CouchDB (201 Created is reserved for genuinely new databases).
 pub async fn put_db(
     State(state): State<AppState>,
     Path(db): Path<String>,
@@ -51,7 +55,9 @@ pub async fn put_db(
         )));
     }
 
-    Ok((StatusCode::CREATED, Json(serde_json::json!({"ok": true}))))
+    Err(AppError(rouchdb_core::error::RouchError::DatabaseExists(
+        db,
+    )))
 }
 
 /// DELETE /{db} — delete a database.

--- a/crates/rouchdb-server/src/routes/document.rs
+++ b/crates/rouchdb-server/src/routes/document.rs
@@ -68,6 +68,13 @@ pub async fn put_doc(
 ) -> Result<(StatusCode, Json<serde_json::Value>), AppError> {
     validate_db(&db, &state)?;
 
+    // Honor a `_deleted: true` body (CouchDB delete-via-PUT).
+    let is_deleted = body
+        .as_object()
+        .and_then(|o| o.get("_deleted"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
     // Get _rev from query param or body
     let rev = query.rev.or_else(|| {
         body.as_object()
@@ -76,7 +83,14 @@ pub async fn put_doc(
             .map(String::from)
     });
 
-    let result = if let Some(rev_str) = rev {
+    let result = if is_deleted {
+        let rev_str = rev.ok_or_else(|| {
+            AppError(rouchdb_core::error::RouchError::BadRequest(
+                "Missing _rev for delete".to_string(),
+            ))
+        })?;
+        state.db.remove(&docid, &rev_str).await?
+    } else if let Some(rev_str) = rev {
         // Strip _id and _rev from body data
         if let Some(obj) = body.as_object_mut() {
             obj.remove("_id");
@@ -91,6 +105,18 @@ pub async fn put_doc(
         }
         state.db.put(&docid, body).await?
     };
+
+    // A failed write returns Ok(DocResult { ok: false, .. }); map it to the
+    // correct HTTP status (409/404/400) instead of reporting 201 Created.
+    if !result.ok {
+        return Err(AppError(match result.error.as_deref() {
+            Some("conflict") => rouchdb_core::error::RouchError::Conflict,
+            Some("not_found") => rouchdb_core::error::RouchError::NotFound(result.id),
+            _ => rouchdb_core::error::RouchError::BadRequest(
+                result.reason.unwrap_or_else(|| "write failed".to_string()),
+            ),
+        }));
+    }
 
     Ok((
         StatusCode::CREATED,
@@ -117,6 +143,14 @@ pub async fn delete_doc(
     })?;
 
     let result = state.db.remove(&docid, &rev).await?;
+    if !result.ok {
+        return Err(AppError(match result.error.as_deref() {
+            Some("not_found") => rouchdb_core::error::RouchError::NotFound(
+                result.reason.unwrap_or_else(|| "missing".to_string()),
+            ),
+            _ => rouchdb_core::error::RouchError::Conflict,
+        }));
+    }
     Ok(Json(serde_json::json!({
         "ok": result.ok,
         "id": result.id,

--- a/crates/rouchdb-server/src/routes/security.rs
+++ b/crates/rouchdb-server/src/routes/security.rs
@@ -5,6 +5,7 @@ use rouchdb::SecurityDocument;
 
 use crate::error::AppError;
 use crate::state::AppState;
+use rouchdb_core::error::RouchError;
 
 fn validate_db(db: &str, state: &AppState) -> Result<(), AppError> {
     if db != state.db_name {
@@ -30,9 +31,15 @@ pub async fn get_security(
 pub async fn put_security(
     State(state): State<AppState>,
     Path(db): Path<String>,
-    Json(body): Json<SecurityDocument>,
+    Json(raw): Json<serde_json::Value>,
 ) -> Result<Json<serde_json::Value>, AppError> {
     validate_db(&db, &state)?;
+
+    // Parse here (instead of via the extractor) so a malformed body yields the
+    // standard CouchDB error JSON rather than axum's default rejection. Unknown
+    // top-level fields are preserved via SecurityDocument::extra.
+    let body: SecurityDocument = serde_json::from_value(raw)
+        .map_err(|e| AppError(RouchError::BadRequest(format!("invalid security doc: {e}"))))?;
 
     state.db.put_security(body).await?;
     Ok(Json(serde_json::json!({"ok": true})))

--- a/crates/rouchdb-views/Cargo.toml
+++ b/crates/rouchdb-views/Cargo.toml
@@ -11,10 +11,10 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.4.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-rouchdb-adapter-memory = { path = "../rouchdb-adapter-memory", version = "0.3.2" }
+rouchdb-adapter-memory = { path = "../rouchdb-adapter-memory", version = "0.4.0" }

--- a/crates/rouchdb-views/src/design_doc.rs
+++ b/crates/rouchdb-views/src/design_doc.rs
@@ -14,7 +14,7 @@ pub struct DesignDocument {
     pub id: String,
     #[serde(rename = "_rev", skip_serializing_if = "Option::is_none")]
     pub rev: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_views")]
     pub views: HashMap<String, ViewDef>,
     #[serde(default)]
     pub filters: HashMap<String, String>,
@@ -38,6 +38,29 @@ pub struct ViewDef {
     pub reduce: Option<String>,
 }
 
+/// Deserialize a design document's `views` object, tolerating CouchDB's
+/// special `lib` (CommonJS shared-library) entry and any other sibling that
+/// is not a `{map, reduce}` view definition. Such entries are skipped rather
+/// than failing the whole parse.
+fn deserialize_views<'de, D>(d: D) -> std::result::Result<HashMap<String, ViewDef>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw: HashMap<String, serde_json::Value> = HashMap::deserialize(d)?;
+    let mut out = HashMap::new();
+    for (k, v) in raw {
+        if k == "lib" {
+            continue;
+        }
+        if v.get("map").and_then(|m| m.as_str()).is_some()
+            && let Ok(def) = serde_json::from_value::<ViewDef>(v)
+        {
+            out.insert(k, def);
+        }
+    }
+    Ok(out)
+}
+
 impl DesignDocument {
     /// Parse a design document from a JSON value.
     pub fn from_json(value: serde_json::Value) -> Result<Self> {
@@ -53,5 +76,27 @@ impl DesignDocument {
     /// Get the design document name without the `_design/` prefix.
     pub fn name(&self) -> &str {
         self.id.strip_prefix("_design/").unwrap_or(&self.id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_ddoc_with_views_lib() {
+        // A CouchDB ddoc may carry a `views.lib` CommonJS shared library; it
+        // must not break parsing of the real views.
+        let json = serde_json::json!({
+            "_id": "_design/x",
+            "views": {
+                "by_name": {"map": "function(doc){ emit(doc.name, 1); }"},
+                "lib": {"shared": "exports.x = 1"}
+            }
+        });
+        let ddoc = DesignDocument::from_json(json).unwrap();
+        assert_eq!(ddoc.views.len(), 1);
+        assert!(ddoc.views.contains_key("by_name"));
+        assert!(!ddoc.views.contains_key("lib"));
     }
 }

--- a/crates/rouchdb/Cargo.toml
+++ b/crates/rouchdb/Cargo.toml
@@ -12,14 +12,14 @@ readme.workspace = true
 
 [dependencies]
 async-trait = "0.1"
-rouchdb-core = { path = "../rouchdb-core", version = "0.3.2" }
-rouchdb-adapter-memory = { path = "../rouchdb-adapter-memory", version = "0.3.2" }
-rouchdb-adapter-redb = { path = "../rouchdb-adapter-redb", version = "0.3.2" }
-rouchdb-adapter-http = { path = "../rouchdb-adapter-http", version = "0.3.2" }
-rouchdb-changes = { path = "../rouchdb-changes", version = "0.3.2" }
-rouchdb-replication = { path = "../rouchdb-replication", version = "0.3.2" }
-rouchdb-query = { path = "../rouchdb-query", version = "0.3.2" }
-rouchdb-views = { path = "../rouchdb-views", version = "0.3.2" }
+rouchdb-core = { path = "../rouchdb-core", version = "0.4.0" }
+rouchdb-adapter-memory = { path = "../rouchdb-adapter-memory", version = "0.4.0" }
+rouchdb-adapter-redb = { path = "../rouchdb-adapter-redb", version = "0.4.0" }
+rouchdb-adapter-http = { path = "../rouchdb-adapter-http", version = "0.4.0" }
+rouchdb-changes = { path = "../rouchdb-changes", version = "0.4.0" }
+rouchdb-replication = { path = "../rouchdb-replication", version = "0.4.0" }
+rouchdb-query = { path = "../rouchdb-query", version = "0.4.0" }
+rouchdb-views = { path = "../rouchdb-views", version = "0.4.0" }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 tokio = { version = "1", features = ["sync"] }

--- a/crates/rouchdb/src/lib.rs
+++ b/crates/rouchdb/src/lib.rs
@@ -199,8 +199,8 @@ impl Database {
             data,
             attachments: HashMap::new(),
         };
-        let mut results = self.bulk_docs(vec![doc], BulkDocsOptions::new()).await?;
-        Ok(results.remove(0))
+        let results = self.bulk_docs(vec![doc], BulkDocsOptions::new()).await?;
+        first_result(results)
     }
 
     /// Update an existing document (requires providing the current rev).
@@ -216,8 +216,8 @@ impl Database {
             data,
             attachments: HashMap::new(),
         };
-        let mut results = self.bulk_docs(vec![doc], BulkDocsOptions::new()).await?;
-        Ok(results.remove(0))
+        let results = self.bulk_docs(vec![doc], BulkDocsOptions::new()).await?;
+        first_result(results)
     }
 
     /// Delete a document (requires the current rev).
@@ -233,8 +233,8 @@ impl Database {
             data: serde_json::json!({}),
             attachments: HashMap::new(),
         };
-        let mut results = self.bulk_docs(vec![doc], BulkDocsOptions::new()).await?;
-        Ok(results.remove(0))
+        let results = self.bulk_docs(vec![doc], BulkDocsOptions::new()).await?;
+        first_result(results)
     }
 
     /// Write multiple documents at once.
@@ -301,27 +301,36 @@ impl Database {
     ) -> (tokio::sync::mpsc::Receiver<ChangeEvent>, ChangesHandle) {
         if let Some(selector) = opts.selector.clone() {
             let user_wants_docs = opts.include_docs;
+            // Push the selector into the stream's filter so `limit` counts only
+            // matching changes (composing with any pre-existing filter).
+            let existing = opts.filter.clone();
+            let filter: ChangesFilter = Arc::new(move |e: &ChangeEvent| {
+                if let Some(ref ex) = existing
+                    && !ex(e)
+                {
+                    return false;
+                }
+                e.doc
+                    .as_ref()
+                    .is_some_and(|d| matches_selector(d, &selector))
+            });
             let inner_opts = ChangesStreamOptions {
                 include_docs: true, // Need docs for selector evaluation
                 selector: None,
+                filter: Some(filter),
                 ..opts
             };
             let (inner_rx, handle) = live_changes(self.adapter.clone(), inner_opts);
-            let (tx, rx) = tokio::sync::mpsc::channel(64);
+            if user_wants_docs {
+                return (inner_rx, handle);
+            }
 
+            // Strip docs the user did not request.
+            let (tx, rx) = tokio::sync::mpsc::channel(64);
             tokio::spawn(async move {
                 let mut inner_rx = inner_rx;
                 while let Some(mut event) = inner_rx.recv().await {
-                    let matches = event
-                        .doc
-                        .as_ref()
-                        .is_some_and(|d| matches_selector(d, &selector));
-                    if !matches {
-                        continue;
-                    }
-                    if !user_wants_docs {
-                        event.doc = None;
-                    }
+                    event.doc = None;
                     if tx.send(event).await.is_err() {
                         break;
                     }
@@ -344,35 +353,41 @@ impl Database {
     ) -> (tokio::sync::mpsc::Receiver<ChangesEvent>, ChangesHandle) {
         if let Some(selector) = opts.selector.clone() {
             let user_wants_docs = opts.include_docs;
+            // Push the selector into the stream's filter so `limit` counts only
+            // matching changes (composing with any pre-existing filter).
+            let existing = opts.filter.clone();
+            let filter: ChangesFilter = Arc::new(move |e: &ChangeEvent| {
+                if let Some(ref ex) = existing
+                    && !ex(e)
+                {
+                    return false;
+                }
+                e.doc
+                    .as_ref()
+                    .is_some_and(|d| matches_selector(d, &selector))
+            });
             let inner_opts = ChangesStreamOptions {
                 include_docs: true,
                 selector: None,
+                filter: Some(filter),
                 ..opts
             };
             let (inner_rx, handle) = live_changes_events(self.adapter.clone(), inner_opts);
-            let (tx, rx) = tokio::sync::mpsc::channel(64);
+            if user_wants_docs {
+                return (inner_rx, handle);
+            }
 
+            // Strip docs the user did not request from Change events.
+            let (tx, rx) = tokio::sync::mpsc::channel(64);
             tokio::spawn(async move {
                 let mut inner_rx = inner_rx;
                 while let Some(event) = inner_rx.recv().await {
-                    let forward = match &event {
-                        ChangesEvent::Change(ce) => {
-                            let matches = ce
-                                .doc
-                                .as_ref()
-                                .is_some_and(|d| matches_selector(d, &selector));
-                            if !matches {
-                                continue;
-                            }
-                            if !user_wants_docs {
-                                let mut ce = ce.clone();
-                                ce.doc = None;
-                                ChangesEvent::Change(ce)
-                            } else {
-                                event
-                            }
+                    let forward = match event {
+                        ChangesEvent::Change(mut ce) => {
+                            ce.doc = None;
+                            ChangesEvent::Change(ce)
                         }
-                        _ => event, // Pass through lifecycle events
+                        other => other,
                     };
                     if tx.send(forward).await.is_err() {
                         break;
@@ -493,8 +508,12 @@ impl Database {
                     use rouchdb_query::SortDirection;
                     for sf in sort_fields {
                         let (field, direction) = sf.field_and_direction();
-                        let va = a.get(field).unwrap_or(&serde_json::Value::Null);
-                        let vb = b.get(field).unwrap_or(&serde_json::Value::Null);
+                        // Resolve dotted/nested paths (e.g. "address.city")
+                        // identically to the full-scan path in mango::find.
+                        let va = rouchdb_query::get_nested_field(a, field)
+                            .unwrap_or(&serde_json::Value::Null);
+                        let vb = rouchdb_query::get_nested_field(b, field)
+                            .unwrap_or(&serde_json::Value::Null);
                         let cmp = collate(va, vb);
                         let cmp = if direction == SortDirection::Desc {
                             cmp.reverse()
@@ -849,6 +868,17 @@ impl Database {
             name: name.to_string(),
         }
     }
+}
+
+/// Extract the single `DocResult` from a one-document `bulk_docs` call.
+///
+/// Returns an error instead of panicking when no result is produced — e.g. a
+/// `before_write` plugin dropped the document, or a custom adapter returned
+/// fewer results than documents.
+fn first_result(results: Vec<DocResult>) -> Result<DocResult> {
+    results.into_iter().next().ok_or_else(|| {
+        RouchError::DatabaseError("bulk_docs returned no result for the written document".into())
+    })
 }
 
 /// Escape regex metacharacters in a string for safe use in a regex pattern.
@@ -1466,5 +1496,74 @@ mod tests {
 
         let info = db.info().await.unwrap();
         assert_eq!(info.doc_count, 0);
+    }
+
+    struct DropAllPlugin;
+
+    #[async_trait::async_trait]
+    impl Plugin for DropAllPlugin {
+        fn name(&self) -> &str {
+            "drop-all"
+        }
+        async fn before_write(&self, docs: &mut Vec<Document>) -> Result<()> {
+            docs.clear(); // simulate a plugin that vetoes the write
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn put_returns_error_when_plugin_drops_document() {
+        let db = Database::memory("test").with_plugin(Arc::new(DropAllPlugin));
+        // Must return an error rather than panicking on an empty results vec.
+        let result = db.put("doc1", serde_json::json!({"v": 1})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn indexed_find_sorts_on_nested_field() {
+        let db = Database::memory("test");
+        db.put(
+            "a",
+            serde_json::json!({"category": "x", "address": {"city": "Zurich"}}),
+        )
+        .await
+        .unwrap();
+        db.put(
+            "b",
+            serde_json::json!({"category": "x", "address": {"city": "Amsterdam"}}),
+        )
+        .await
+        .unwrap();
+        db.put(
+            "c",
+            serde_json::json!({"category": "x", "address": {"city": "Madrid"}}),
+        )
+        .await
+        .unwrap();
+
+        // Index on "category" so the index-accelerated find() path is taken.
+        db.create_index(IndexDefinition {
+            name: String::new(),
+            fields: vec![SortField::Simple("category".into())],
+            ddoc: None,
+        })
+        .await
+        .unwrap();
+
+        let result = db
+            .find(FindOptions {
+                selector: serde_json::json!({"category": "x"}),
+                sort: Some(vec![SortField::Simple("address.city".into())]),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let cities: Vec<&str> = result
+            .docs
+            .iter()
+            .map(|d| d["address"]["city"].as_str().unwrap())
+            .collect();
+        assert_eq!(cities, vec!["Amsterdam", "Madrid", "Zurich"]);
     }
 }

--- a/crates/rouchdb/src/lib.rs
+++ b/crates/rouchdb/src/lib.rs
@@ -1337,12 +1337,10 @@ mod tests {
                                 break;
                             }
                         }
-                        Some(ReplicationEvent::Paused) => {
-                            // No changes, check if doc was replicated
-                            if remote.get("doc1").await.is_ok() {
-                                got_complete = true;
-                                break;
-                            }
+                        // No changes — check whether the doc was replicated.
+                        Some(ReplicationEvent::Paused) if remote.get("doc1").await.is_ok() => {
+                            got_complete = true;
+                            break;
                         }
                         None => break,
                         _ => {}

--- a/crates/rouchdb/tests/bug_hunting.rs
+++ b/crates/rouchdb/tests/bug_hunting.rs
@@ -764,6 +764,7 @@ async fn security_overwrite() {
             roles: vec![],
         },
         members: SecurityGroup::default(),
+        ..Default::default()
     };
     db.put_security(sec1).await.unwrap();
 
@@ -773,6 +774,7 @@ async fn security_overwrite() {
             roles: vec!["role1".into()],
         },
         members: SecurityGroup::default(),
+        ..Default::default()
     };
     db.put_security(sec2).await.unwrap();
 

--- a/crates/rouchdb/tests/edge_cases.rs
+++ b/crates/rouchdb/tests/edge_cases.rs
@@ -647,9 +647,10 @@ async fn view_reduce_with_zero_emitted_rows() {
     .await
     .unwrap();
 
-    // Should handle empty reduce gracefully
-    assert_eq!(result.rows.len(), 1);
-    assert_eq!(result.rows[0].value, serde_json::json!(0));
+    // An empty reduce returns no rows (CouchDB returns {"rows":[]}), not a
+    // spurious zero row.
+    assert!(result.rows.is_empty());
+    assert_eq!(result.total_rows, 0);
 }
 
 // =========================================================================

--- a/crates/rouchdb/tests/parity_core.rs
+++ b/crates/rouchdb/tests/parity_core.rs
@@ -364,6 +364,7 @@ async fn security_document_put_and_get() {
             names: vec!["user1".into(), "user2".into()],
             roles: vec!["readers".into()],
         },
+        ..Default::default()
     };
 
     db.put_security(sec).await.unwrap();

--- a/crates/rouchdb/tests/parity_replication.rs
+++ b/crates/rouchdb/tests/parity_replication.rs
@@ -256,11 +256,9 @@ async fn live_replication_picks_up_new_docs() {
                         initial_done = true;
                         break;
                     }
-                    Some(ReplicationEvent::Paused) => {
-                        if target.get("doc1").await.is_ok() {
-                            initial_done = true;
-                            break;
-                        }
+                    Some(ReplicationEvent::Paused) if target.get("doc1").await.is_ok() => {
+                        initial_done = true;
+                        break;
                     }
                     None => break,
                     _ => {}

--- a/crates/rouchdb/tests/replication.rs
+++ b/crates/rouchdb/tests/replication.rs
@@ -996,11 +996,7 @@ async fn live_replicate_to_couchdb() {
             event = rx.recv() => {
                 match event {
                     Some(ReplicationEvent::Complete(r)) if r.docs_written > 0 => break,
-                    Some(ReplicationEvent::Paused) => {
-                        if remote.get("doc1").await.is_ok() {
-                            break;
-                        }
-                    }
+                    Some(ReplicationEvent::Paused) if remote.get("doc1").await.is_ok() => break,
                     None => break,
                     _ => {}
                 }
@@ -1075,11 +1071,9 @@ async fn live_replicate_picks_up_new_docs() {
                         replicated = true;
                         break;
                     }
-                    Some(ReplicationEvent::Paused) => {
-                        if remote.get("late_doc").await.is_ok() {
-                            replicated = true;
-                            break;
-                        }
+                    Some(ReplicationEvent::Paused) if remote.get("late_doc").await.is_ok() => {
+                        replicated = true;
+                        break;
                     }
                     None => break,
                     _ => {}


### PR DESCRIPTION
## Summary

A deep, multi-agent audit (17 specialized finder agents + per-finding adversarial verification) surfaced 51 candidate issues → **46 confirmed** → **44 unique bugs** across every crate. This PR fixes all 44 and bumps the workspace to **v0.4.0** (correctness release, no new features).

- ~25 regression tests added → **366 unit tests pass**
- `cargo clippy -D warnings` and `cargo fmt --check` clean
- 3 commits: the fixes, the CHANGELOG entry, the version bump

## ⚠️ Migration notes (0.3.2 → 0.4.0)

Full guide in [CHANGELOG.md](CHANGELOG.md). Highlights:

**API (may break compilation):**
- `ChangesEvent` has a new `Heartbeat` variant — exhaustive `match`es need a new arm
- New public fields: `DbInfo.doc_del_count`, `SecurityDocument.extra`, `CheckpointDoc._rev`; `Checkpointer::new` takes a filter-fingerprint argument

**Behavior:**
- Replication checkpoints are invalidated once — first run after upgrade re-scans from seq 0 (idempotent, no data loss)
- Server status codes now match CouchDB: 409 on PUT conflict, 409/404 on DELETE, 412 on existing-db PUT
- `PUT` with `_deleted:true` now deletes; `get(latest=true)` returns the branch leaf; empty reduce returns `{"rows":[]}`; `Revision` rejects an empty hash; plugin-dropped writes return `Err` instead of panicking

## Highest-impact fixes

- **Core:** rev-tree stemming now prunes past branch points (`revs_limit`); collation preserves precision for integers > 2^53; inline attachments serialize as base64
- **Adapters:** memory adapter persists attachments (were silently lost); redb descending key-range + no-panic on corrupt record + single-txn reads; HTTP url-encodes params and preserves `_design/`
- **Replication:** filter in replication id; checkpoint `_rev` round-trip + history accumulation; doesn't advance past failed docs; counts only successful writes; carries attachments (memory)
- **Query/Changes/CLI:** `$elemMatch` on scalars; `skip`/`limit` on reduce; `group_level=0`; `limit` counts post-filter; `heartbeat` honored; `import`/`put --force` surface failures

## Known gaps (documented, not in this PR)

- Attachment replication is end-to-end only for the **memory** adapter; redb uses a different attachment storage scheme (follow-up)
- HTTP-adapter-only paths are validated by reasoning + unit tests; CouchDB integration tests are `#[ignore]` (need a live CouchDB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)