### PR TITLE
docs: fix Book link to renamed org Pages URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ RouchDB is a workspace of 11 crates:
 
 ## Documentation
 
-- [**Book**](https://rubylabapp.github.io/rouchdb/) — guides, reference, and architecture docs
+- [**Book**](https://rubylab-app.github.io/rouchdb/) — guides, reference, and architecture docs
 - [**API Docs**](https://docs.rs/rouchdb) — generated Rust docs
 
 ## Development


### PR DESCRIPTION
The README **Book** link still pointed at the pre-rename Pages host `rubylabapp.github.io`. Updated to `rubylab-app.github.io` to match the org rename.

One-line docs fix. The root `README.md` is also the `rouchdb` crate readme, so this corrects the link shown on crates.io too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)